### PR TITLE
Small fixes

### DIFF
--- a/codegen/examples/hashed_keys.rs
+++ b/codegen/examples/hashed_keys.rs
@@ -4,10 +4,12 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use core::hint::black_box;
-use frozen_collections::maps::EytzingerSearchMap;
-use frozen_collections::{FzOrderedMap, MapQuery};
+use frozen_collections::hashers::BridgeHasher;
+use frozen_collections::maps::HashMap;
+use frozen_collections::{FzHashMap, MapQuery};
+use hashbrown::HashMap as HashbrownMap;
 
-#[derive(Ord, PartialOrd, PartialEq, Eq, Clone)]
+#[derive(Hash, PartialEq, Eq, Clone)]
 struct MyKey {
     name: String,
     city: String,
@@ -59,19 +61,27 @@ fn main() {
         ),
     ];
 
-    let fm = FzOrderedMap::new(v.clone());
-    let esm = EytzingerSearchMap::new(v.clone());
+    let fm = FzHashMap::new(v.clone());
+    let cm = HashMap::with_hasher(v.clone(), BridgeHasher::default()).unwrap();
+    let mut hm = HashbrownMap::with_capacity(v.len());
+    hm.extend(v.clone());
 
-    _ = black_box(call_facade_ordered_map(&fm, &v[0].0));
-    _ = black_box(call_eytzinger_search_map(&esm, &v[0].0));
+    _ = black_box(call_fz_hash_map_with_bridge_hasher(&fm, &v[0].0));
+    _ = black_box(call_hash_map_with_bridge_hasher(&cm, &v[0].0));
+    _ = black_box(call_hashbrown_map(&hm, &v[0].0));
 }
 
 #[inline(never)]
-fn call_facade_ordered_map(map: &FzOrderedMap<MyKey, i32>, key: &MyKey) -> bool {
+fn call_fz_hash_map_with_bridge_hasher(map: &FzHashMap<MyKey, i32>, key: &MyKey) -> bool {
     map.contains_key(key)
 }
 
 #[inline(never)]
-fn call_eytzinger_search_map(map: &EytzingerSearchMap<MyKey, i32>, key: &MyKey) -> bool {
+fn call_hash_map_with_bridge_hasher(map: &HashMap<MyKey, i32>, key: &MyKey) -> bool {
+    map.contains_key(key)
+}
+
+#[inline(never)]
+fn call_hashbrown_map(map: &HashbrownMap<MyKey, i32>, key: &MyKey) -> bool {
     map.contains_key(key)
 }

--- a/codegen/examples/ordered_keys.rs
+++ b/codegen/examples/ordered_keys.rs
@@ -4,12 +4,10 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use core::hint::black_box;
-use frozen_collections::hashers::BridgeHasher;
-use frozen_collections::maps::HashMap;
-use frozen_collections::{FzHashMap, MapQuery};
-use hashbrown::HashMap as HashbrownMap;
+use frozen_collections::maps::EytzingerSearchMap;
+use frozen_collections::{FzOrderedMap, MapQuery};
 
-#[derive(Hash, PartialEq, Eq, Clone)]
+#[derive(Ord, PartialOrd, PartialEq, Eq, Clone)]
 struct MyKey {
     name: String,
     city: String,
@@ -61,27 +59,19 @@ fn main() {
         ),
     ];
 
-    let fm = FzHashMap::new(v.clone());
-    let cm = HashMap::with_hasher(v.clone(), BridgeHasher::default()).unwrap();
-    let mut hm = HashbrownMap::with_capacity(v.len());
-    hm.extend(v.clone());
+    let fm = FzOrderedMap::new(v.clone());
+    let esm = EytzingerSearchMap::new(v.clone());
 
-    _ = black_box(call_facade_hash_map_with_bridge_hasher(&fm, &v[0].0));
-    _ = black_box(call_hash_map_with_bridge_hasher(&cm, &v[0].0));
-    _ = black_box(call_hashbrown_map(&hm, &v[0].0));
+    _ = black_box(call_fz_ordered_map(&fm, &v[0].0));
+    _ = black_box(call_eytzinger_search_map(&esm, &v[0].0));
 }
 
 #[inline(never)]
-fn call_facade_hash_map_with_bridge_hasher(map: &FzHashMap<MyKey, i32>, key: &MyKey) -> bool {
+fn call_fz_ordered_map(map: &FzOrderedMap<MyKey, i32>, key: &MyKey) -> bool {
     map.contains_key(key)
 }
 
 #[inline(never)]
-fn call_hash_map_with_bridge_hasher(map: &HashMap<MyKey, i32>, key: &MyKey) -> bool {
-    map.contains_key(key)
-}
-
-#[inline(never)]
-fn call_hashbrown_map(map: &HashbrownMap<MyKey, i32>, key: &MyKey) -> bool {
+fn call_eytzinger_search_map(map: &EytzingerSearchMap<MyKey, i32>, key: &MyKey) -> bool {
     map.contains_key(key)
 }

--- a/codegen/examples/scalar_keys.rs
+++ b/codegen/examples/scalar_keys.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 use alloc::vec;
 use core::hint::black_box;
 use frozen_collections::hashers::PassthroughHasher;
+use frozen_collections::inline_maps::InlineScanMap;
 use frozen_collections::maps::{
     BinarySearchMap, DenseScalarLookupMap, EytzingerSearchMap, HashMap, OrderedScanMap, ScanMap,
     SparseScalarLookupMap,
@@ -55,9 +56,29 @@ fn main() {
         _ = black_box(call_eytzinger_search_map(&map, key));
     }
 
-    let map = FzScalarMap::new(input);
+    let map = FzScalarMap::new(input.clone());
+    for key in probe.clone() {
+        _ = black_box(call_fz_scalar_map(&map, key));
+    }
+
+    let map = InlineScanMap::new_raw([]);
+    for key in probe.clone() {
+        _ = black_box(call_inline_scan_map_0_entries(&map, key));
+    }
+
+    let map = InlineScanMap::new_raw([input[0]]);
+    for key in probe.clone() {
+        _ = black_box(call_inline_scan_map_1_entries(&map, key));
+    }
+
+    let map = InlineScanMap::new_raw([input[0], input[1]]);
+    for key in probe.clone() {
+        _ = black_box(call_inline_scan_map_2_entries(&map, key));
+    }
+
+    let map = InlineScanMap::new_raw([input[0], input[1], input[2]]);
     for key in probe {
-        _ = black_box(call_facade_scalar_map(&map, key));
+        _ = black_box(call_inline_scan_map_3_entries(&map, key));
     }
 }
 
@@ -85,7 +106,7 @@ fn call_sparse_scalar_lookup_map(map: &SparseScalarLookupMap<i32, i32>, key: i32
 }
 
 #[inline(never)]
-fn call_facade_scalar_map(map: &FzScalarMap<i32, i32>, key: i32) -> bool {
+fn call_fz_scalar_map(map: &FzScalarMap<i32, i32>, key: i32) -> bool {
     map.contains_key(&key)
 }
 
@@ -106,5 +127,25 @@ fn call_scan_map(map: &ScanMap<i32, i32>, key: i32) -> bool {
 
 #[inline(never)]
 fn call_ordered_scan_map(map: &OrderedScanMap<i32, i32>, key: i32) -> bool {
+    map.contains_key(&key)
+}
+
+#[inline(never)]
+fn call_inline_scan_map_0_entries(map: &InlineScanMap<i32, i32, 0>, key: i32) -> bool {
+    map.contains_key(&key)
+}
+
+#[inline(never)]
+fn call_inline_scan_map_1_entries(map: &InlineScanMap<i32, i32, 1>, key: i32) -> bool {
+    map.contains_key(&key)
+}
+
+#[inline(never)]
+fn call_inline_scan_map_2_entries(map: &InlineScanMap<i32, i32, 2>, key: i32) -> bool {
+    map.contains_key(&key)
+}
+
+#[inline(never)]
+fn call_inline_scan_map_3_entries(map: &InlineScanMap<i32, i32, 3>, key: i32) -> bool {
     map.contains_key(&key)
 }

--- a/codegen/examples/string_keys_length.rs
+++ b/codegen/examples/string_keys_length.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let map = FzStringMap::new(input.iter().map(|x| (*x.0, *x.1)).collect());
     for key in probe {
-        _ = black_box(call_facade_string_map(&map, key));
+        _ = black_box(call_fz_string_map(&map, key));
     }
 
     let map = input;
@@ -49,6 +49,6 @@ fn call_inline_hash_map_with_passthrough_hasher(map: &MyMapType, key: &str) -> b
 }
 
 #[inline(never)]
-fn call_facade_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
+fn call_fz_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
     map.contains_key(key)
 }

--- a/codegen/examples/string_keys_subslice.rs
+++ b/codegen/examples/string_keys_subslice.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let map = FzStringMap::new(input.iter().map(|x| (*x.0, *x.1)).collect());
     for key in probe {
-        _ = black_box(call_facade_string_map(&map, key));
+        _ = black_box(call_fz_string_map(&map, key));
     }
 
     let map = input;
@@ -41,7 +41,7 @@ fn call_hashbrown_map(map: &HashbrownMap<&str, i32>, key: &str) -> bool {
 }
 
 #[inline(never)]
-fn call_facade_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
+fn call_fz_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
     map.contains_key(key)
 }
 

--- a/frozen-collections-core/src/emit/collection_emitter.rs
+++ b/frozen-collections-core/src/emit/collection_emitter.rs
@@ -392,7 +392,7 @@ impl CollectionEmitter {
     ) -> Result<TokenStream, String> {
         let gen = self.preflight(entries.len())?;
         let output = if entries.len() < SCAN_THRESHOLD {
-            gen.gen_scan(entries)
+            gen.gen_inline_scan(entries)
         } else {
             gen.gen_hash_with_bridge(entries)
         };
@@ -407,7 +407,7 @@ impl CollectionEmitter {
     ) -> Result<TokenStream, String> {
         let gen = self.preflight(entries.len())?;
         let output = if entries.len() < SCAN_THRESHOLD {
-            gen.gen_scan(entries)
+            gen.gen_inline_scan(entries)
         } else if entries.len() < ORDERED_SCAN_THRESHOLD {
             gen.gen_ordered_scan(entries)
         } else if entries.len() < BINARY_SEARCH_THRESHOLD {
@@ -426,9 +426,9 @@ impl CollectionEmitter {
     ) -> Result<TokenStream, String> {
         let gen = self.preflight(entries.len())?;
         let output = if entries.len() < SCAN_THRESHOLD {
-            gen.gen_scan(entries)
+            gen.gen_inline_scan(entries)
         } else {
-            gen.gen_facade_scalar(entries)
+            gen.gen_fz_scalar(entries)
         };
 
         self.postflight(output)
@@ -441,9 +441,9 @@ impl CollectionEmitter {
     ) -> Result<TokenStream, String> {
         let gen = self.preflight(entries.len())?;
         let output = if entries.len() < SCAN_THRESHOLD {
-            gen.gen_scan(entries)
+            gen.gen_inline_scan(entries)
         } else {
-            gen.gen_facade_string(entries)
+            gen.gen_fz_string(entries)
         };
 
         self.postflight(output)

--- a/frozen-collections-core/src/emit/generator.rs
+++ b/frozen-collections-core/src/emit/generator.rs
@@ -48,7 +48,7 @@ impl Generator {
     }
 
     /*
-        pub fn gen_facade_hash<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
+        pub fn gen_fz_hash<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
             let key_type = &self.key_type;
             let value_type = &self.value_type;
 
@@ -69,7 +69,7 @@ impl Generator {
             Output { ctor, type_sig }
         }
 
-        pub fn gen_facade_ordered<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
+        pub fn gen_fz_ordered<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
             let key_type = &self.key_type;
             let value_type = &self.value_type;
 
@@ -92,7 +92,7 @@ impl Generator {
     */
 
     #[cfg(feature = "macros")]
-    pub fn gen_facade_scalar<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
+    pub fn gen_fz_scalar<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
         let key_type = &self.key_type;
         let value_type = &self.value_type;
 
@@ -114,7 +114,7 @@ impl Generator {
     }
 
     #[cfg(feature = "macros")]
-    pub fn gen_facade_string<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
+    pub fn gen_fz_string<K>(self, entries: Vec<CollectionEntry<K>>) -> Output {
         let key_type = &self.key_type;
         let value_type = &self.value_type;
 
@@ -497,30 +497,6 @@ impl Generator {
 
         if self.gen_set {
             ty = quote!(::frozen_collections::sets::OrderedScanSet);
-            generics = quote!(<#key_type>);
-            type_sig = quote!(#ty::#generics);
-            ctor = quote!(#type_sig::new(#ctor));
-        }
-
-        Output { ctor, type_sig }
-    }
-
-    #[cfg(feature = "macros")]
-    pub fn gen_scan<K>(&self, entries: Vec<CollectionEntry<K>>) -> Output {
-        let key_type = &self.key_type;
-        let value_type = &self.value_type;
-
-        let mut ty = quote!(::frozen_collections::maps::ScanMap);
-        let mut generics = quote!(<#key_type, #value_type>);
-        let mut type_sig = quote!(#ty::#generics);
-        let mut ctor = quote!(#type_sig::new(vec![
-            #(
-                #entries,
-            )*
-        ]));
-
-        if self.gen_set {
-            ty = quote!(::frozen_collections::sets::ScanSet);
             generics = quote!(<#key_type>);
             type_sig = quote!(#ty::#generics);
             ctor = quote!(#type_sig::new(#ctor));

--- a/frozen-collections-core/src/fz_maps/fz_hash_map.rs
+++ b/frozen-collections-core/src/fz_maps/fz_hash_map.rs
@@ -68,7 +68,7 @@ where
         dedup_by_hash_keep_last(&mut entries, |x| bh.hash_one(&x.0), |x, y| x.0 == y.0);
 
         Self {
-            map_impl: if entries.len() < 3 {
+            map_impl: if entries.len() < 4 {
                 MapTypes::Scanning(ScanMap::new_raw(entries))
             } else {
                 MapTypes::Hash(

--- a/frozen-collections-core/src/macros/macro_api.rs
+++ b/frozen-collections-core/src/macros/macro_api.rs
@@ -263,7 +263,7 @@ mod tests {
             quote!({ "1111", "1112", "1113", "1114", "1115", "1116", "1117" }),
         );
 
-        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4", "5", "6"}));
         check_impl(
@@ -287,7 +287,7 @@ mod tests {
         check_impl(":: InlineOrderedScanSet", quote!({ 1, 2, 3, 4, 5, 10000 }));
         check_impl(":: InlineHashSet", quote!({ 1, 2, 3, 4, 5, 6, 10000 }));
 
-        check_impl(":: ScanSet", quote!({ x, 2, 3, }));
+        check_impl(":: InlineScanSet", quote!({ x, 2, 3, }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6}));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
@@ -317,7 +317,7 @@ mod tests {
             quote!({ "1", "2", "3", "4", "5", "6", "7" }),
         );
 
-        check_impl(":: ScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
+        check_impl(":: InlineScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
         check_impl(
             ":: OrderedScanSet",
             quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }),
@@ -343,12 +343,12 @@ mod tests {
             }),
         );
 
-        check_impl(":: ScanSet", quote!({ x, 2, 3, }));
+        check_impl(":: InlineScanSet", quote!({ x, 2, 3, }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6}));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
 
-        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4", "5", "6"}));
         check_impl(
@@ -381,18 +381,18 @@ mod tests {
             quote!({ "1", "2", "3", "4", "5", "6", "7" }),
         );
 
-        check_impl(":: ScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
+        check_impl(":: InlineScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
         check_impl(
             ":: HashSet",
             quote!({ Foo(1), Foo(2), Foo(3), Foo(4), Foo(5), Foo(6), Foo(7) }),
         );
 
-        check_impl(":: ScanSet", quote!({ x, 2, 3, }));
+        check_impl(":: InlineScanSet", quote!({ x, 2, 3, }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6}));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
 
-        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4", "5", "6"}));
         check_impl(

--- a/frozen-collections-core/src/traits/set_query.rs
+++ b/frozen-collections-core/src/traits/set_query.rs
@@ -5,6 +5,7 @@ use core::hash::{BuildHasher, Hash};
 pub trait SetQuery<T, Q: ?Sized = T> {
     /// Checks whether a particular value is present in the set.
     #[must_use]
+    #[inline]
     fn contains(&self, value: &Q) -> bool {
         self.get(value).is_some()
     }


### PR DESCRIPTION
- Use InlineScanMap instead of ScanMap in a few places to shave a few cycles in handling small collections.

- TUrned the codegen stuff back from tests into examples. Otherwise for some reason, the generated code doesn't contain the functions I'm trying to look at.

- Purge remaining "facde" terminology from the codebase.