### PR TITLE
Major update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,16 +46,27 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rustfmt
+      - name: Install Rust Nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
       - name: Install cargo-audit
         run: cargo install cargo-audit
+      - name: Install cargo-machete
+        run: cargo install cargo-machete
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Audit
         run: cargo audit
+      - name: Machete
+        run: cargo machete
       - name: Format
         run: cargo fmt -- --check
       - name: Docs
         run: RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps --all-features
+      - name: Miri
+        run: cargo +nightly miri test --test omni_tests
 
   coverage:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## 0.6.0 - 2025-06-21
+
+### Added
+
 - Added the get_disjoint_unchecked_mut function to the Map trait to match what HashMap has.
 
 ### Changed
 
 - The get_many_mut function on the Map trait has been renamed to get_disjoint_mut to match the stable name
 used in HashMap.
+
+- Improved usability by implementing all the methods that
+were previously just on the traits as normal methods on the
+collections themselves. This avoids the need to import
+the traits to use the collections, making them more user-friendly.
+
+- Revamped the FzStringMap/Set types. Their implementation
+is now simpler, yet the API is more flexible.
+
+- Tidied up a lot of generic bounds. Many of the
+bounds are removed, making the types easier to use
+
+- SetQuery and MapQuery now have one fewer generics,
+making them considerably easier and natural to use.
+
+- Enabled more lints and fixed the resulting warnings.
 
 ## 0.5.0 - 2025-04-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 categories = ["data-structures", "no-std"]
 keywords = ["map", "set", "collection"]
@@ -17,7 +17,7 @@ repository = "https://github.com/geeknoid/frozen-collections"
 license = "MIT"
 authors = ["Martin Taillefer <martin@taillefer.org>"]
 readme = "README.md"
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 
 [workspace.dependencies]
 frozen-collections = { path = "frozen-collections", default-features = false }
@@ -42,12 +42,17 @@ syn = { version = "2.0.101", default-features = false }
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"
 missing_debug_implementations = "warn"
-#redundant_imports = "warn"
+missing_docs = "warn"
+redundant_imports = "warn"
 redundant_lifetimes = "warn"
 single_use_lifetimes = "warn"
 trivial_numeric_casts = "warn"
 unsafe_op_in_unsafe_fn = "warn"
+unused_extern_crates = "warn"
+unused_import_braces = "warn"
 unused_lifetimes = "warn"
+unused_macro_rules = "warn"
+unused_qualifications = "warn"
 unused_results = "warn"
 
 [workspace.lints.clippy]
@@ -59,11 +64,54 @@ pedantic = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 
+# Explicitly enabled lints from the `restriction` group.
+alloc_instead_of_core = "warn"
+allow_attributes_without_reason = "warn"
+as_underscore = "warn"
+as_pointer_underscore = "warn"
+clone_on_ref_ptr = "warn"
+deref_by_slicing = "warn"
+disallowed_script_idents = "warn"
+empty_drop = "warn"
+empty_enum_variants_with_brackets = "warn"
+empty_structs_with_brackets = "warn"
+filetype_is_file = "warn"
+fn_to_numeric_cast_any = "warn"
+get_unwrap = "warn"
+if_then_some_else_none = "warn"
+infinite_loop = "warn"
+map_err_ignore = "warn"
+missing_asserts_for_indexing = "warn"
+multiple_unsafe_ops_per_block = "warn"
+mutex_atomic = "warn"
+mutex_integer = "warn"
+needless_raw_strings = "warn"
+print_stderr = "warn"
+print_stdout = "warn"
+rc_buffer = "warn"
+rc_mutex = "warn"
+redundant_type_annotations = "warn"
+renamed_function_params = "warn"
+rest_pat_in_fully_bound_structs = "warn"
+return_and_then = "warn"
+semicolon_outside_block = "warn"
+std_instead_of_core = "warn"
+string_lit_chars_any = "warn"
+string_slice = "warn"
+string_to_string = "warn"
+suspicious_xor_used_as_pow = "warn"
+try_err = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unnecessary_safety_doc = "warn"
+unnecessary_self_imports = "warn"
+unneeded_field_pattern = "warn"
+unused_result_ok = "warn"
+unwrap_in_result = "warn"
+
 # turn off annoying ones...
 too_many_lines = "allow"
 from-iter-instead-of-collect = "allow"
-into_iter_without_iter = "allow"
-inline_always = "allow"
 cognitive_complexity = "allow"
 
 [profile.bench]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/frozen-collections/badge.svg)](https://docs.rs/frozen-collections)
 [![CI](https://github.com/geeknoid/frozen-collections/workflows/main/badge.svg)](https://github.com/geeknoid/frozen-collections/actions)
 [![Coverage](https://codecov.io/gh/geeknoid/frozen-collections/graph/badge.svg?token=FCUG0EL5TI)](https://codecov.io/gh/geeknoid/frozen-collections)
-[![Minimum Supported Rust Version 1.85](https://img.shields.io/badge/MSRV-1.85-blue.svg)]()
+[![Minimum Supported Rust Version 1.87](https://img.shields.io/badge/MSRV-1.87-blue.svg)]()
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 * [Summary](#summary)
@@ -196,18 +196,18 @@ collection instances.
 
 The maps produced by this crate implement the following traits:
 
-- [`Map`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html). The primary representation of a map. This trait has [`MapQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapQuery.html) and
-  [`MapIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapIteration.html) as super-traits.
-- [`MapQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapQuery.html). A trait for querying maps. This is an object-safe trait.
-- [`MapIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapIteration.html). A trait for iterating over maps.
+- [`Map`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html). The primary representation of a map.
+- [`MapQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapQuery.html). A dyn compatible trait for querying maps.
+- [`MapIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapIteration.html). A dyn compatible trait for iterating over maps.
+- [`MapExtras`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.MapExtras.html). A trait for extra map operations.
 
 The sets produced by this crate implement the following traits:
 
-- [`Set`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Set.html). The primary representation of a set. This trait has [`SetQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html),
-  [`SetIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html) and [`SetOps`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html) as super-traits.
-- [`SetQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html). A trait for querying sets. This is an object-safe trait.
-- [`SetIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html). A trait for iterating over sets.
-- [`SetOps`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Map.html). A trait for set operations like union and intersections.
+- [`Set`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.Set.html). The primary representation of a set.
+- [`SetQuery`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.SetQuery.html). A dyn compatible trait for querying sets.
+- [`SetIteration`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.SetIteration.html). A dyn compatible trait for iterating over sets.
+- [`SetOps`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.SetOps.html). A trait for set operations like union and intersections.
+- [`SetExtras`](https://docs.rs/frozen-collections/latest/frozen_collections/trait.SetExtras.html). A trait for extra set operations.
 
 ## Performance Considerations
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,1 @@
-Integrate https://github.com/d1manson/rust-simd-psmap
+* Integrate https://github.com/d1manson/rust-simd-psmap

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dev-dependencies]
-frozen-collections = { workspace = true, features = ["macros", "std"] }
+frozen-collections = { workspace = true, features = ["macros"] }
 hashbrown = { workspace = true }
 
 [lints]

--- a/codegen/examples/hashed_keys.rs
+++ b/codegen/examples/hashed_keys.rs
@@ -1,12 +1,14 @@
+//! Validates quality of generated code
+
 #![no_std]
 extern crate alloc;
 
 use alloc::string::{String, ToString};
 use alloc::vec;
 use core::hint::black_box;
+use frozen_collections::FzHashMap;
 use frozen_collections::hashers::BridgeHasher;
 use frozen_collections::maps::HashMap;
-use frozen_collections::{FzHashMap, MapQuery};
 use hashbrown::HashMap as HashbrownMap;
 
 #[derive(Hash, PartialEq, Eq, Clone)]

--- a/codegen/examples/ordered_keys.rs
+++ b/codegen/examples/ordered_keys.rs
@@ -1,11 +1,13 @@
+//! Validates quality of generated code
+
 #![no_std]
 extern crate alloc;
 
 use alloc::string::{String, ToString};
 use alloc::vec;
 use core::hint::black_box;
+use frozen_collections::FzOrderedMap;
 use frozen_collections::maps::{BinarySearchMap, EytzingerSearchMap};
-use frozen_collections::{FzOrderedMap, MapQuery};
 
 #[derive(Ord, PartialOrd, PartialEq, Eq, Clone)]
 struct MyKey {

--- a/codegen/examples/scalar_keys.rs
+++ b/codegen/examples/scalar_keys.rs
@@ -1,3 +1,5 @@
+//! Validates quality of generated code
+
 #![no_std]
 extern crate alloc;
 
@@ -6,7 +8,7 @@ use core::hint::black_box;
 use frozen_collections::hashers::PassthroughHasher;
 use frozen_collections::inline_maps::InlineScanMap;
 use frozen_collections::maps::{DenseScalarLookupMap, HashMap, ScanMap, SparseScalarLookupMap};
-use frozen_collections::{FzScalarMap, MapQuery, SmallCollection};
+use frozen_collections::{FzScalarMap, SmallCollection};
 use hashbrown::HashMap as HashbrownMap;
 
 fn main() {
@@ -18,7 +20,7 @@ fn main() {
         _ = black_box(call_hashbrown_map(&map, key));
     }
 
-    let map = HashMap::with_hasher(input.clone(), PassthroughHasher::default()).unwrap();
+    let map = HashMap::with_hasher(input.clone(), PassthroughHasher {}).unwrap();
     for key in probe.clone() {
         _ = black_box(call_hash_map_with_passthrough_hasher(&map, key));
     }
@@ -70,10 +72,7 @@ fn call_hashbrown_map(map: &HashbrownMap<i32, i32>, key: i32) -> bool {
 }
 
 #[inline(never)]
-fn call_hash_map_with_passthrough_hasher(
-    map: &HashMap<i32, i32, SmallCollection, PassthroughHasher>,
-    key: i32,
-) -> bool {
+fn call_hash_map_with_passthrough_hasher(map: &HashMap<i32, i32, SmallCollection, PassthroughHasher>, key: i32) -> bool {
     map.contains_key(&key)
 }
 

--- a/codegen/examples/string_keys_length.rs
+++ b/codegen/examples/string_keys_length.rs
@@ -1,26 +1,18 @@
+//! Validates quality of generated code
+
 #![no_std]
 extern crate alloc;
 
+use alloc::boxed::Box;
 use core::hint::black_box;
-use frozen_collections::{FzStringMap, MapIteration, MapQuery, fz_string_map};
+use frozen_collections::{FzStringMap, fz_string_map};
 use hashbrown::HashMap as HashbrownMap;
 
 fz_string_map!(static MAP: MyMapType<&'static str, i32>, { "1": 1, "22":2, "333":3, "4444":4, "55555":5, "666666":6, "7777777":7, "88888888":8, "999999999":9 });
 
 fn main() {
     let input = MAP.clone();
-    let probe = [
-        "0",
-        "1",
-        "22",
-        "333",
-        "4444",
-        "A",
-        "B",
-        "C",
-        "D",
-        "ABCDEFGHIJKL",
-    ];
+    let probe = ["0", "1", "22", "333", "4444", "A", "B", "C", "D", "ABCDEFGHIJKL"];
 
     let map: HashbrownMap<_, _> = input.iter().map(|x| (*x.0, *x.1)).collect();
     for key in probe {
@@ -49,6 +41,6 @@ fn call_inline_hash_map_with_passthrough_hasher(map: &MyMapType, key: &str) -> b
 }
 
 #[inline(never)]
-fn call_fz_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
+fn call_fz_string_map(map: &FzStringMap<Box<str>, i32>, key: &str) -> bool {
     map.contains_key(key)
 }

--- a/codegen/examples/string_keys_subslice.rs
+++ b/codegen/examples/string_keys_subslice.rs
@@ -1,21 +1,18 @@
+//! Validates quality of generated code
+
 #![no_std]
 extern crate alloc;
 
+use alloc::boxed::Box;
 use core::hint::black_box;
-use frozen_collections::{FzStringMap, MapIteration, MapQuery, fz_string_map};
+use frozen_collections::{FzStringMap, fz_string_map};
 use hashbrown::HashMap as HashbrownMap;
 
 fz_string_map!(static MAP: MyMapType<&'static str, i32>, { "ALongPrefixRedd": 1, "ALongPrefixGree":2, "ALongPrefixBlue":3, "ALongPrefixCyan":4, "ALongPrefixPurple":5, "ALongPrefix:Yellow":6, "ALongPrefixMagenta":7 });
 
 fn main() {
     let input = MAP.clone();
-    let probe = [
-        "ALongPrefixRedd",
-        "ALongPrefixCyan",
-        "Tomato",
-        "Potato",
-        "Carrot",
-    ];
+    let probe = ["ALongPrefixRedd", "ALongPrefixCyan", "Tomato", "Potato", "Carrot"];
 
     let map: HashbrownMap<_, _> = input.iter().map(|x| (*x.0, *x.1)).collect();
     for key in probe {
@@ -29,9 +26,7 @@ fn main() {
 
     let map = input;
     for key in probe {
-        _ = black_box(call_inline_hash_map_with_inline_left_range_hasher(
-            &map, key,
-        ));
+        _ = black_box(call_inline_hash_map_with_inline_left_range_hasher(&map, key));
     }
 }
 
@@ -41,7 +36,7 @@ fn call_hashbrown_map(map: &HashbrownMap<&str, i32>, key: &str) -> bool {
 }
 
 #[inline(never)]
-fn call_fz_string_map(map: &FzStringMap<&str, i32>, key: &str) -> bool {
+fn call_fz_string_map(map: &FzStringMap<Box<str>, i32>, key: &str) -> bool {
     map.contains_key(key)
 }
 

--- a/frozen-collections-core/Cargo.toml
+++ b/frozen-collections-core/Cargo.toml
@@ -19,7 +19,7 @@ hashbrown = { workspace = true, features = ["default-hasher"] }
 mutants = { workspace = true }
 proc-macro2 = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["alloc"] }
 syn = { workspace = true, optional = true, features = ["printing", "parsing", "clone-impls", "derive", "extra-traits"], default-features = false }
 
 [dev-dependencies]

--- a/frozen-collections-core/src/analyzers/scalar_key_analyzer.rs
+++ b/frozen-collections-core/src/analyzers/scalar_key_analyzer.rs
@@ -38,9 +38,7 @@ where
     let needed_count = max - min + 1;
     if needed_count == count {
         ScalarKeyAnalysisResult::DenseRange
-    } else if needed_count <= ALWAYS_SPARSE_THRESHOLD
-        || needed_count < count.saturating_mul(MAX_SPARSE_MULTIPLIER)
-    {
+    } else if needed_count <= ALWAYS_SPARSE_THRESHOLD || needed_count < count.saturating_mul(MAX_SPARSE_MULTIPLIER) {
         ScalarKeyAnalysisResult::SparseRange
     } else {
         ScalarKeyAnalysisResult::General
@@ -51,7 +49,6 @@ where
 mod tests {
     use super::*;
     use alloc::vec;
-    use alloc::vec::Vec;
 
     #[test]
     fn test_analyze_scalar_keys_empty() {
@@ -62,19 +59,13 @@ mod tests {
     #[test]
     fn test_analyze_scalar_keys_dense_range() {
         let keys = 1..=5;
-        assert_eq!(
-            analyze_scalar_keys(keys),
-            ScalarKeyAnalysisResult::DenseRange
-        );
+        assert_eq!(analyze_scalar_keys(keys), ScalarKeyAnalysisResult::DenseRange);
     }
 
     #[test]
     fn test_analyze_scalar_keys_sparse_range() {
         let keys = vec![1, 3, 5, 7, 128].into_iter();
-        assert_eq!(
-            analyze_scalar_keys(keys),
-            ScalarKeyAnalysisResult::SparseRange
-        );
+        assert_eq!(analyze_scalar_keys(keys), ScalarKeyAnalysisResult::SparseRange);
     }
 
     #[test]

--- a/frozen-collections-core/src/analyzers/slice_key_analyzer.rs
+++ b/frozen-collections-core/src/analyzers/slice_key_analyzer.rs
@@ -1,9 +1,11 @@
-use alloc::vec::Vec;
 use core::cmp::{max, min};
 use core::hash::{BuildHasher, Hash};
 use core::ops::Range;
 use hashbrown::HashMap as HashbrownMap;
 use hashbrown::HashSet as HashbrownSet;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// How to treat keys which are slices for the best performance.
 #[derive(PartialEq, Eq, Debug)]
@@ -75,6 +77,7 @@ fn analyze_lengths<T>(keys: &Vec<&[T]>) -> SliceKeyAnalysisResult {
 }
 
 /// See if we can use subslices to reduce the time spent hashing
+#[expect(clippy::missing_asserts_for_indexing, reason = "There is in fact an assert present")]
 fn analyze_subslices<T, BH>(keys: &[&[T]], bh: &BH) -> SliceKeyAnalysisResult
 where
     T: Hash + Eq,
@@ -100,6 +103,8 @@ where
         if s.len() < suffix_len {
             suffix_len = s.len();
         }
+
+        assert!(!keys.is_empty());
 
         for i in 0..prefix_len {
             if s[i] != keys[0][i] {
@@ -131,21 +136,11 @@ where
         // If any is above our threshold, we're done.
         let mut subslice_index = prefix_len;
         while subslice_index <= min_len - subslice_len {
-            if is_sufficiently_unique(
-                keys,
-                subslice_index,
-                subslice_len,
-                true,
-                &mut set,
-                acceptable_duplicates,
-                bh,
-            ) {
+            if is_sufficiently_unique(keys, subslice_index, subslice_len, true, &mut set, acceptable_duplicates, bh) {
                 return if subslice_len == max_len {
                     SliceKeyAnalysisResult::General
                 } else {
-                    SliceKeyAnalysisResult::LeftHandSubslice(
-                        subslice_index..subslice_index + subslice_len,
-                    )
+                    SliceKeyAnalysisResult::LeftHandSubslice(subslice_index..subslice_index + subslice_len)
                 };
             }
 
@@ -161,18 +156,8 @@ where
             // If any is above our threshold, we're done.
             subslice_index = suffix_len;
             while subslice_index <= min_len - subslice_len {
-                if is_sufficiently_unique(
-                    keys,
-                    subslice_index,
-                    subslice_len,
-                    false,
-                    &mut set,
-                    acceptable_duplicates,
-                    bh,
-                ) {
-                    return SliceKeyAnalysisResult::RightHandSubslice(
-                        subslice_index..subslice_index + subslice_len,
-                    );
+                if is_sufficiently_unique(keys, subslice_index, subslice_len, false, &mut set, acceptable_duplicates, bh) {
+                    return SliceKeyAnalysisResult::RightHandSubslice(subslice_index..subslice_index + subslice_len);
                 }
 
                 subslice_index += 1;
@@ -224,7 +209,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::{String, ToString};
     use foldhash::fast::RandomState;
 
     struct AnalysisTestCase<'a> {
@@ -237,8 +221,8 @@ mod tests {
         const ANALYSIS_TEST_CASES: [AnalysisTestCase; 9] = [
             AnalysisTestCase {
                 slices: &[
-                    "AAA", "ABB", "ACC", "ADD", "AEE", "AFF", "AGG", "AHH", "AII", "AJJ", "AKK",
-                    "ALL", "AMM", "ANN", "AOO", "APP", "AQQ", "ARR", "ASS", "ATT", "AUU",
+                    "AAA", "ABB", "ACC", "ADD", "AEE", "AFF", "AGG", "AHH", "AII", "AJJ", "AKK", "ALL", "AMM", "ANN", "AOO", "APP", "AQQ",
+                    "ARR", "ASS", "ATT", "AUU",
                 ],
                 expected: SliceKeyAnalysisResult::LeftHandSubslice(1..2),
             },
@@ -267,9 +251,7 @@ mod tests {
                 expected: SliceKeyAnalysisResult::Length,
             },
             AnalysisTestCase {
-                slices: &[
-                    "ABC", "DEFG", "HIJKL", "MNOPQR", "STUVWX", "YZ", "D2", "D3", "D4",
-                ],
+                slices: &["ABC", "DEFG", "HIJKL", "MNOPQR", "STUVWX", "YZ", "D2", "D3", "D4"],
                 expected: SliceKeyAnalysisResult::LeftHandSubslice(1..2),
             },
             AnalysisTestCase {
@@ -280,10 +262,7 @@ mod tests {
 
         for case in &ANALYSIS_TEST_CASES {
             let keys = case.slices.iter().map(|x| x.as_bytes());
-            assert_eq!(
-                case.expected,
-                analyze_slice_keys(keys, &RandomState::default())
-            );
+            assert_eq!(case.expected, analyze_slice_keys(keys, &RandomState::default()));
         }
     }
 

--- a/frozen-collections-core/src/doc_snippets/contains.md
+++ b/frozen-collections-core/src/doc_snippets/contains.md
@@ -1,0 +1,1 @@
+Checks whether a particular value is present in the set.

--- a/frozen-collections-core/src/doc_snippets/contains_key.md
+++ b/frozen-collections-core/src/doc_snippets/contains_key.md
@@ -1,0 +1,3 @@
+Returns `true` if the map contains a value for the specified key.
+
+The key may be any borrowed form of the map’s key type.    

--- a/frozen-collections-core/src/doc_snippets/get.md
+++ b/frozen-collections-core/src/doc_snippets/get.md
@@ -1,0 +1,3 @@
+Returns a reference to the value corresponding to the key.
+
+The key may be any borrowed form of the map’s key type.

--- a/frozen-collections-core/src/doc_snippets/get_disjoint_mut.md
+++ b/frozen-collections-core/src/doc_snippets/get_disjoint_mut.md
@@ -1,0 +1,5 @@
+Gets multiple mutable values from the map.
+
+# Panics
+
+Panics if the same key is specified multiple times.

--- a/frozen-collections-core/src/doc_snippets/get_disjoint_unchecked_mut.md
+++ b/frozen-collections-core/src/doc_snippets/get_disjoint_unchecked_mut.md
@@ -1,0 +1,6 @@
+Gets multiple mutable values from the map.
+
+# Safety
+
+Calling this method with overlapping keys is [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html)
+even if the resulting references are not used.

--- a/frozen-collections-core/src/doc_snippets/get_from_set.md
+++ b/frozen-collections-core/src/doc_snippets/get_from_set.md
@@ -1,0 +1,1 @@
+Gets a reference to a value in the set.

--- a/frozen-collections-core/src/doc_snippets/get_key_value.md
+++ b/frozen-collections-core/src/doc_snippets/get_key_value.md
@@ -1,0 +1,9 @@
+Returns the key-value pair corresponding to the supplied key.
+
+This is potentially useful:
+
+- for key types where non-identical keys can be considered equal;
+- for getting the &K stored key value from a borrowed &Q lookup key; or
+- for getting a reference to a key with the same lifetime as the collection.
+
+- The supplied key may be any borrowed form of the map’s key type, but Hash and Eq on the borrowed form must match those for the key type.

--- a/frozen-collections-core/src/doc_snippets/get_mut.md
+++ b/frozen-collections-core/src/doc_snippets/get_mut.md
@@ -1,0 +1,3 @@
+Returns a mutable reference to the value corresponding to the key.
+
+The key may be any borrowed form of the map’s key type.

--- a/frozen-collections-core/src/doc_snippets/into_keys.md
+++ b/frozen-collections-core/src/doc_snippets/into_keys.md
@@ -1,0 +1,1 @@
+A consuming iterator visiting all keys in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/into_values.md
+++ b/frozen-collections-core/src/doc_snippets/into_values.md
@@ -1,0 +1,1 @@
+A consuming iterator visiting all values in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/is_empty.md
+++ b/frozen-collections-core/src/doc_snippets/is_empty.md
@@ -1,0 +1,1 @@
+Returns `true` if the collection contains no elements.

--- a/frozen-collections-core/src/doc_snippets/iter.md
+++ b/frozen-collections-core/src/doc_snippets/iter.md
@@ -1,0 +1,1 @@
+An iterator visiting all entries in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/iter_mut.md
+++ b/frozen-collections-core/src/doc_snippets/iter_mut.md
@@ -1,0 +1,1 @@
+An iterator producing mutable references to all entries in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/keys.md
+++ b/frozen-collections-core/src/doc_snippets/keys.md
@@ -1,0 +1,1 @@
+An iterator visiting all keys in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/len.md
+++ b/frozen-collections-core/src/doc_snippets/len.md
@@ -1,0 +1,1 @@
+Returns the number of elements in the collection.

--- a/frozen-collections-core/src/doc_snippets/values.md
+++ b/frozen-collections-core/src/doc_snippets/values.md
@@ -1,0 +1,1 @@
+An iterator visiting all values in arbitrary order.

--- a/frozen-collections-core/src/doc_snippets/values_mut.md
+++ b/frozen-collections-core/src/doc_snippets/values_mut.md
@@ -1,0 +1,1 @@
+An iterator visiting all values mutably in arbitrary order.

--- a/frozen-collections-core/src/emit/collection_entry.rs
+++ b/frozen-collections-core/src/emit/collection_entry.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::redundant_pub_crate)]
+#![expect(clippy::redundant_pub_crate, reason = "Helps clarity")]
 
 use core::fmt::{Debug, Formatter};
 use proc_macro2::TokenStream;
@@ -8,6 +8,7 @@ use syn::{Expr, parse_quote};
 #[cfg(feature = "macros")]
 pub(crate) struct NonLiteralKey;
 
+/// Represents an entry in a collection used to build a frozen collection.
 pub struct CollectionEntry<K> {
     pub(crate) key: K,
     key_expr: Expr,
@@ -15,14 +16,12 @@ pub struct CollectionEntry<K> {
 }
 
 impl<K> CollectionEntry<K> {
+    /// Creates a new `CollectionEntry` for a map, using the specified key, key expression, and value expression.
     pub const fn map_entry(key: K, key_expr: Expr, value_expr: Expr) -> Self {
-        Self {
-            key,
-            key_expr,
-            value_expr,
-        }
+        Self { key, key_expr, value_expr }
     }
 
+    /// Creates a new `CollectionEntry` for a set, using the specified value and value expression.
     pub fn set_entry(value: K, value_expr: Expr) -> Self {
         Self {
             key: value,
@@ -67,6 +66,7 @@ where
         )
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,9 +127,6 @@ mod tests {
         let entry = CollectionEntry::map_entry(key, key_expr, value_expr);
         let debug_str = format!("{entry:?}");
 
-        assert_eq!(
-            debug_str,
-            "CollectionEntry { key: \"key\", key_expr 'key', value_expr: 'value'}"
-        );
+        assert_eq!(debug_str, "CollectionEntry { key: \"key\", key_expr 'key', value_expr: 'value'}");
     }
 }

--- a/frozen-collections-core/src/fz_sets/fz_string_set.rs
+++ b/frozen-collections-core/src/fz_sets/fz_string_set.rs
@@ -1,24 +1,20 @@
 use crate::DefaultHashBuilder;
 use crate::fz_maps::FzStringMap;
-use crate::hashers::{LeftRangeHasher, RightRangeHasher};
-use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, into_iter_fn, into_iter_ref_fn, partial_eq_fn,
-    set_iteration_funcs, sub_fn,
-};
+use crate::maps::decl_macros::len_trait_funcs;
+use crate::sets::decl_macros::{debug_trait_funcs, partial_eq_trait_funcs};
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Hasher, Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
-use alloc::string::String;
-use alloc::vec::Vec;
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::BuildHasher;
-use core::hash::Hash;
-use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
-use equivalent::Equivalent;
 use foldhash::fast::RandomState;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::vec::Vec};
+
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     core::fmt::Formatter,
     core::marker::PhantomData,
     serde::de::{SeqAccess, Visitor},
@@ -36,267 +32,243 @@ use {
 /// If your values are known at compile time, consider using the various `fz_*_set` macros instead of
 /// this type as they generally perform better.
 #[derive(Clone)]
-pub struct FzStringSet<T, BH = DefaultHashBuilder> {
-    map: FzStringMap<T, (), BH>,
+pub struct FzStringSet<K, BH = DefaultHashBuilder> {
+    map: FzStringMap<K, (), BH>,
 }
 
-impl<'a> FzStringSet<&'a str, DefaultHashBuilder> {
+impl FzStringSet<Box<str>, DefaultHashBuilder> {
     /// Creates a new frozen set.
     #[must_use]
-    pub fn new(entries: Vec<&'a str>) -> Self {
+    pub fn new(entries: Vec<impl AsRef<str>>) -> Self {
         Self::with_hasher(entries, RandomState::default())
     }
 }
 
-impl FzStringSet<String, DefaultHashBuilder> {
-    /// Creates a new frozen set.
-    #[must_use]
-    pub fn new_with_strings(entries: Vec<String>) -> Self {
-        Self::with_strings_and_hasher(entries, RandomState::default())
-    }
-}
-
-impl<'a, BH> FzStringSet<&'a str, BH>
-where
-    BH: BuildHasher,
-{
+impl<BH> FzStringSet<Box<str>, BH> {
     /// Creates a new frozen set which uses the given hash builder to hash values.
     #[must_use]
-    pub fn with_hasher(entries: Vec<&'a str>, bh: BH) -> Self {
+    pub fn with_hasher(entries: Vec<impl AsRef<str>>, bh: BH) -> Self
+    where
+        BH: BuildHasher,
+    {
         Self {
             map: FzStringMap::with_hasher(entries.into_iter().map(|x| (x, ())).collect(), bh),
         }
     }
-}
 
-impl<BH> FzStringSet<String, BH>
-where
-    BH: BuildHasher,
-{
-    /// Creates a new frozen set which uses the given hash builder to hash values.
-    #[must_use]
-    pub fn with_strings_and_hasher(entries: Vec<String>, bh: BH) -> Self {
-        Self {
-            map: FzStringMap::with_strings_and_hasher(
-                entries.into_iter().map(|x| (x, ())).collect(),
-                bh,
-            ),
-        }
-    }
-}
-
-impl<BH> Default for FzStringSet<&str, BH>
-where
-    BH: Default,
-{
-    fn default() -> Self {
-        Self {
-            map: FzStringMap::default(),
-        }
-    }
-}
-
-impl<BH> Default for FzStringSet<String, BH>
-where
-    BH: Default,
-{
-    fn default() -> Self {
-        Self {
-            map: FzStringMap::default(),
-        }
-    }
-}
-
-impl<'a, BH> From<FzStringMap<&'a str, (), BH>> for FzStringSet<&'a str, BH> {
-    fn from(map: FzStringMap<&'a str, (), BH>) -> Self {
-        Self { map }
-    }
-}
-
-impl<BH> From<FzStringMap<String, (), BH>> for FzStringSet<String, BH> {
-    fn from(map: FzStringMap<String, (), BH>) -> Self {
-        Self { map }
-    }
-}
-
-impl<'a, const N: usize, BH> From<[&'a str; N]> for FzStringSet<&'a str, BH>
-where
-    BH: BuildHasher + Default,
-{
-    fn from(entries: [&'a str; N]) -> Self {
-        Self::from(FzStringMap::from_iter(entries.into_iter().map(|x| (x, ()))))
-    }
-}
-
-impl<const N: usize, BH> From<[String; N]> for FzStringSet<String, BH>
-where
-    BH: BuildHasher + Default,
-{
-    fn from(entries: [String; N]) -> Self {
-        Self::from(FzStringMap::from_iter(entries.into_iter().map(|x| (x, ()))))
-    }
-}
-
-impl<'a, BH> FromIterator<&'a str> for FzStringSet<&'a str, BH>
-where
-    BH: BuildHasher + Default,
-{
-    fn from_iter<IT: IntoIterator<Item = &'a str>>(iter: IT) -> Self {
-        Self::from(FzStringMap::from_iter(iter.into_iter().map(|x| (x, ()))))
-    }
-}
-
-impl<BH> FromIterator<String> for FzStringSet<String, BH>
-where
-    BH: BuildHasher + Default,
-{
-    fn from_iter<IT: IntoIterator<Item = String>>(iter: IT) -> Self {
-        Self::from(FzStringMap::from_iter(iter.into_iter().map(|x| (x, ()))))
-    }
-}
-
-impl<T, Q, BH> Set<T, Q> for FzStringSet<T, BH>
-where
-    Q: ?Sized + Hash + Eq + Len + Equivalent<T>,
-    BH: BuildHasher,
-    LeftRangeHasher<BH>: Hasher<Q>,
-    RightRangeHasher<BH>: Hasher<Q>,
-{
-}
-
-impl<T, Q, BH> SetQuery<T, Q> for FzStringSet<T, BH>
-where
-    Q: ?Sized + Hash + Eq + Len + Equivalent<T>,
-    BH: BuildHasher,
-    LeftRangeHasher<BH>: Hasher<Q>,
-    RightRangeHasher<BH>: Hasher<Q>,
-{
+    #[doc = include_str!("../doc_snippets/get_from_set.md")]
     #[inline]
-    fn get(&self, value: &Q) -> Option<&T> {
+    #[expect(clippy::borrowed_box, reason = "By design")]
+    pub fn get(&self, value: impl AsRef<str>) -> Option<&Box<str>>
+    where
+        BH: BuildHasher,
+    {
         Some(self.map.get_key_value(value)?.0)
     }
-}
 
-impl<T, BH> SetIteration<T> for FzStringSet<T, BH> {
-    type Iterator<'a>
-        = Iter<'a, T>
+    #[doc = include_str!("../doc_snippets/contains.md")]
+    #[inline]
+    #[must_use]
+    pub fn contains(&self, value: impl AsRef<str>) -> bool
     where
-        T: 'a,
-        BH: 'a;
+        BH: BuildHasher,
+    {
+        self.map.contains_key(value)
+    }
 
-    set_iteration_funcs!();
-}
-
-impl<T, BH> Len for FzStringSet<T, BH> {
-    fn len(&self) -> usize {
+    #[doc = include_str!("../doc_snippets/len.md")]
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
         self.map.len()
     }
-}
 
-impl<T, ST, BH> BitOr<&ST> for &FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len + Clone,
-    ST: Set<T>,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-    bitor_fn!();
-}
+    #[doc = include_str!("../doc_snippets/is_empty.md")]
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 
-impl<T, ST, BH> BitAnd<&ST> for &FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len + Clone,
-    ST: Set<T>,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-    bitand_fn!();
-}
+    #[doc = include_str!("../doc_snippets/iter.md")]
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, Box<str>> {
+        Iter::new(self.map.iter())
+    }
 
-impl<T, ST, BH> BitXor<&ST> for &FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len + Clone,
-    ST: Set<T>,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-    bitxor_fn!();
-}
-
-impl<T, ST, BH> Sub<&ST> for &FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len + Clone,
-    ST: Set<T>,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-    sub_fn!();
-}
-
-impl<T, BH> IntoIterator for FzStringSet<T, BH> {
-    into_iter_fn!();
-}
-
-impl<'a, T, BH> IntoIterator for &'a FzStringSet<T, BH> {
-    into_iter_ref_fn!();
-}
-
-impl<T, ST, BH> PartialEq<ST> for FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len,
-    ST: Set<T>,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-    partial_eq_fn!();
-}
-
-impl<T, BH> Eq for FzStringSet<T, BH>
-where
-    T: Hash + Eq + Len,
-    BH: BuildHasher + Default,
-    LeftRangeHasher<BH>: Hasher<T>,
-    RightRangeHasher<BH>: Hasher<T>,
-{
-}
-
-impl<T, BH> Debug for FzStringSet<T, BH>
-where
-    T: Debug,
-{
-    debug_fn!();
-}
-
-#[cfg(feature = "serde")]
-impl<T> Serialize for FzStringSet<T>
-where
-    T: Serialize,
-{
-    serialize_fn!();
-}
-
-#[cfg(feature = "serde")]
-impl<'de, BH> Deserialize<'de> for FzStringSet<&'de str, BH>
-where
-    BH: BuildHasher + Default,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(StrSetVisitor {
-            marker: PhantomData,
-        })
+    fn into_iter(self) -> IntoIter<Box<str>> {
+        IntoIter::new(self.map.into_iter())
     }
 }
 
+impl<BH> Default for FzStringSet<Box<str>, BH>
+where
+    BH: Default,
+{
+    fn default() -> Self {
+        Self {
+            map: FzStringMap::default(),
+        }
+    }
+}
+
+impl<BH> From<FzStringMap<Box<str>, (), BH>> for FzStringSet<Box<str>, BH> {
+    fn from(map: FzStringMap<Box<str>, (), BH>) -> Self {
+        Self { map }
+    }
+}
+
+impl<T, const N: usize, BH> From<[T; N]> for FzStringSet<Box<str>, BH>
+where
+    T: AsRef<str>,
+    BH: BuildHasher + Default,
+{
+    fn from(entries: [T; N]) -> Self {
+        Self::from(FzStringMap::from_iter(entries.into_iter().map(|x| (x, ()))))
+    }
+}
+
+impl<T, BH> FromIterator<T> for FzStringSet<Box<str>, BH>
+where
+    T: AsRef<str>,
+    BH: BuildHasher + Default,
+{
+    fn from_iter<IT: IntoIterator<Item = T>>(iter: IT) -> Self {
+        Self::from(FzStringMap::from_iter(iter.into_iter().map(|x| (x, ()))))
+    }
+}
+
+impl<Q, BH> Set<Box<str>, Q> for FzStringSet<Box<str>, BH>
+where
+    Q: AsRef<str>,
+    BH: BuildHasher,
+{
+}
+
+impl<Q, BH> SetExtras<Box<str>, Q> for FzStringSet<Box<str>, BH>
+where
+    Q: AsRef<str>,
+    BH: BuildHasher,
+{
+    #[inline]
+    fn get(&self, value: &Q) -> Option<&Box<str>> {
+        self.get(value)
+    }
+}
+
+impl<Q, BH> SetQuery<Q> for FzStringSet<Box<str>, BH>
+where
+    Q: AsRef<str>,
+    BH: BuildHasher,
+{
+    #[inline]
+    fn contains(&self, value: &Q) -> bool {
+        self.contains(value)
+    }
+}
+
+impl<BH> SetIteration<Box<str>> for FzStringSet<Box<str>, BH> {
+    type Iterator<'a>
+        = Iter<'a, Box<str>>
+    where
+        BH: 'a;
+
+    fn iter(&self) -> Iter<'_, Box<str>> {
+        self.iter()
+    }
+}
+
+impl<BH> Len for FzStringSet<Box<str>, BH> {
+    len_trait_funcs!();
+}
+
+impl<ST, BH> BitOr<&ST> for &FzStringSet<Box<str>, BH>
+where
+    ST: Set<Box<str>>,
+    BH: BuildHasher + Default,
+{
+    type Output = hashbrown::HashSet<Box<str>>;
+
+    fn bitor(self, rhs: &ST) -> Self::Output {
+        Self::Output::from_iter(self.union(rhs).cloned())
+    }
+}
+
+impl<ST, BH> BitAnd<&ST> for &FzStringSet<Box<str>, BH>
+where
+    ST: Set<Box<str>>,
+    BH: BuildHasher + Default,
+{
+    type Output = hashbrown::HashSet<Box<str>>;
+
+    fn bitand(self, rhs: &ST) -> Self::Output {
+        Self::Output::from_iter(self.intersection(rhs).cloned())
+    }
+}
+
+impl<ST, BH> BitXor<&ST> for &FzStringSet<Box<str>, BH>
+where
+    ST: Set<Box<str>>,
+    BH: BuildHasher + Default,
+{
+    type Output = hashbrown::HashSet<Box<str>>;
+
+    fn bitxor(self, rhs: &ST) -> Self::Output {
+        self.symmetric_difference(rhs).cloned().collect()
+    }
+}
+
+impl<ST, BH> Sub<&ST> for &FzStringSet<Box<str>, BH>
+where
+    ST: Set<Box<str>>,
+    BH: BuildHasher + Default,
+{
+    type Output = hashbrown::HashSet<Box<str>>;
+
+    fn sub(self, rhs: &ST) -> Self::Output {
+        self.difference(rhs).cloned().collect()
+    }
+}
+
+impl<BH> IntoIterator for FzStringSet<Box<str>, BH> {
+    type Item = Box<str>;
+    type IntoIter = IntoIter<Box<str>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_iter()
+    }
+}
+
+impl<'a, BH> IntoIterator for &'a FzStringSet<Box<str>, BH> {
+    type Item = &'a Box<str>;
+    type IntoIter = Iter<'a, Box<str>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<ST, BH> PartialEq<ST> for FzStringSet<Box<str>, BH>
+where
+    ST: SetQuery<Box<str>>,
+    BH: BuildHasher + Default,
+{
+    partial_eq_trait_funcs!();
+}
+
+impl<BH> Eq for FzStringSet<Box<str>, BH> where BH: BuildHasher + Default {}
+
+impl<BH> Debug for FzStringSet<Box<str>, BH> {
+    debug_trait_funcs!();
+}
+
 #[cfg(feature = "serde")]
-impl<'de, BH> Deserialize<'de> for FzStringSet<String, BH>
+impl Serialize for FzStringSet<Box<str>> {
+    serialize_trait_funcs!();
+}
+
+#[cfg(feature = "serde")]
+impl<'de, BH> Deserialize<'de> for FzStringSet<Box<str>, BH>
 where
     BH: BuildHasher + Default,
 {
@@ -304,9 +276,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_seq(StringSetVisitor {
-            marker: PhantomData,
-        })
+        deserializer.deserialize_seq(StrSetVisitor { marker: PhantomData })
     }
 }
 
@@ -320,56 +290,21 @@ impl<'de, BH> Visitor<'de> for StrSetVisitor<BH>
 where
     BH: BuildHasher + Default,
 {
-    type Value = FzStringSet<&'de str, BH>;
+    type Value = FzStringSet<Box<str>, BH>;
 
     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("a set with string values")
     }
 
-    fn visit_seq<M>(self, mut access: M) -> core::result::Result<Self::Value, M::Error>
+    fn visit_seq<M>(self, mut seq: M) -> Result<Self::Value, M::Error>
     where
         M: SeqAccess<'de>,
     {
-        let mut v = Vec::with_capacity(access.size_hint().unwrap_or(0));
-        while let Some(x) = access.next_element()? {
+        let mut v: Vec<(&str, ())> = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(x) = seq.next_element()? {
             v.push((x, ()));
         }
 
-        Ok(FzStringSet::from(FzStringMap::with_hasher(
-            v,
-            BH::default(),
-        )))
-    }
-}
-
-#[cfg(feature = "serde")]
-struct StringSetVisitor<BH> {
-    marker: PhantomData<BH>,
-}
-
-#[cfg(feature = "serde")]
-impl<'de, BH> Visitor<'de> for StringSetVisitor<BH>
-where
-    BH: BuildHasher + Default,
-{
-    type Value = FzStringSet<String, BH>;
-
-    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
-        formatter.write_str("a set with string values")
-    }
-
-    fn visit_seq<M>(self, mut access: M) -> core::result::Result<Self::Value, M::Error>
-    where
-        M: SeqAccess<'de>,
-    {
-        let mut v = Vec::with_capacity(access.size_hint().unwrap_or(0));
-        while let Some(x) = access.next_element::<&str>()? {
-            v.push((::alloc::string::String::from(x), ()));
-        }
-
-        Ok(FzStringSet::from(FzStringMap::with_strings_and_hasher(
-            v,
-            BH::default(),
-        )))
+        Ok(FzStringSet::from(FzStringMap::with_hasher(v, BH::default())))
     }
 }

--- a/frozen-collections-core/src/hash_tables/hash_table_slot.rs
+++ b/frozen-collections-core/src/hash_tables/hash_table_slot.rs
@@ -5,18 +5,15 @@
 /// A slot contains the range of indices in the table's entry vector
 /// that contain entries that hash to this slot.
 #[derive(Clone, Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct HashTableSlot<CM> {
     pub(crate) min_index: CM,
     pub(crate) max_index: CM,
 }
 
 impl<CM> HashTableSlot<CM> {
+    /// Creates a new hash table slot with the specified minimum and maximum indices.
     pub const fn new(min_index: CM, max_index: CM) -> Self {
-        Self {
-            min_index,
-            max_index,
-        }
+        Self { min_index, max_index }
     }
 }
 
@@ -26,8 +23,6 @@ impl quote::ToTokens for HashTableSlot<usize> {
         let min_index = proc_macro2::Literal::usize_unsuffixed(self.min_index);
         let max_index = proc_macro2::Literal::usize_unsuffixed(self.max_index);
 
-        tokens.extend(
-            quote::quote!(::frozen_collections::hash_tables::HashTableSlot::new(#min_index, #max_index)),
-        );
+        tokens.extend(quote::quote!(::frozen_collections::hash_tables::HashTableSlot::new(#min_index, #max_index)));
     }
 }

--- a/frozen-collections-core/src/hashers/bridge_hasher.rs
+++ b/frozen-collections-core/src/hashers/bridge_hasher.rs
@@ -11,6 +11,7 @@ pub struct BridgeHasher<BH = DefaultHashBuilder> {
 }
 
 impl<BH> BridgeHasher<BH> {
+    /// Creates a new `BridgeHasher` with the given `BuildHasher` to bridge to.
     #[must_use]
     pub const fn new(bh: BH) -> Self {
         Self { bh }

--- a/frozen-collections-core/src/hashers/inline_left_range_hasher.rs
+++ b/frozen-collections-core/src/hashers/inline_left_range_hasher.rs
@@ -1,32 +1,28 @@
 use crate::DefaultHashBuilder;
 use crate::traits::Hasher;
 use crate::utils::cold;
-use alloc::string::String;
 use core::hash::{BuildHasher, Hash};
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 /// Hashes a portion of a left-aligned slice.
 ///
 #[doc = include_str!("../doc_snippets/private_api_warning.md")]
 #[derive(Clone, Debug)]
-pub struct InlineLeftRangeHasher<
-    const RANGE_START: usize,
-    const RANGE_END: usize,
-    BH = DefaultHashBuilder,
-> {
+pub struct InlineLeftRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = DefaultHashBuilder> {
     bh: BH,
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH>
-    InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
-{
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> InlineLeftRangeHasher<RANGE_START, RANGE_END, BH> {
+    /// Creates a new `InlineLeftRangeHasher` with the specified `BuildHasher`.
     #[must_use]
     pub const fn new(bh: BH) -> Self {
         Self { bh }
     }
 }
 
-impl<T, const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<[T]>
-    for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
+impl<T, const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<[T]> for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
 where
     T: Hash,
     BH: BuildHasher,
@@ -42,8 +38,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<String>
-    for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<String> for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -59,8 +54,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<&str>
-    for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<&str> for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -76,8 +70,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<str>
-    for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<str> for InlineLeftRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -96,7 +89,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
     use alloc::vec;
     use foldhash::fast::RandomState;
 

--- a/frozen-collections-core/src/hashers/inline_right_range_hasher.rs
+++ b/frozen-collections-core/src/hashers/inline_right_range_hasher.rs
@@ -1,32 +1,28 @@
 use crate::DefaultHashBuilder;
 use crate::traits::Hasher;
 use crate::utils::cold;
-use alloc::string::String;
 use core::hash::{BuildHasher, Hash};
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 /// Hashes a portion of a right-aligned slice.
 ///
 #[doc = include_str!("../doc_snippets/private_api_warning.md")]
 #[derive(Clone, Debug)]
-pub struct InlineRightRangeHasher<
-    const RANGE_START: usize,
-    const RANGE_END: usize,
-    BH = DefaultHashBuilder,
-> {
+pub struct InlineRightRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = DefaultHashBuilder> {
     bh: BH,
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH>
-    InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
-{
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> InlineRightRangeHasher<RANGE_START, RANGE_END, BH> {
+    /// Creates a new `InlineRightRangeHasher` with the specified `BuildHasher`.
     #[must_use]
     pub const fn new(bh: BH) -> Self {
         Self { bh }
     }
 }
 
-impl<T, const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<[T]>
-    for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
+impl<T, const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<[T]> for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
 where
     T: Hash,
     BH: BuildHasher,
@@ -43,8 +39,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<String>
-    for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<String> for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -61,8 +56,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<&str>
-    for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<&str> for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -79,8 +73,7 @@ where
     }
 }
 
-impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<str>
-    for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
+impl<const RANGE_START: usize, const RANGE_END: usize, BH> Hasher<str> for InlineRightRangeHasher<RANGE_START, RANGE_END, BH>
 where
     BH: BuildHasher,
 {
@@ -100,17 +93,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
     use alloc::vec;
     use foldhash::fast::RandomState;
 
     #[test]
     fn test_right_range_hasher_hash_slice() {
         let hasher = InlineRightRangeHasher::<1, 3>::new(RandomState::default());
-        assert_eq!(
-            hasher.hash(vec![1, 2, 3, 4].as_slice()),
-            hasher.bh.hash_one(vec![2, 3].as_slice())
-        );
+        assert_eq!(hasher.hash(vec![1, 2, 3, 4].as_slice()), hasher.bh.hash_one(vec![2, 3].as_slice()));
         assert_eq!(
             hasher.hash(vec![1, 2, 3, 4, 5, 6].as_slice()),
             hasher.bh.hash_one(vec![4, 5].as_slice())
@@ -121,14 +110,8 @@ mod tests {
     #[test]
     fn test_right_range_hasher_hash_string() {
         let hasher = InlineRightRangeHasher::<3, 5>::new(RandomState::default());
-        assert_eq!(
-            hasher.hash(&"abcdef".to_string()),
-            hasher.bh.hash_one(b"bc")
-        );
-        assert_eq!(
-            hasher.hash(&"abcdefghijklmn".to_string()),
-            hasher.bh.hash_one(b"jk")
-        );
+        assert_eq!(hasher.hash(&"abcdef".to_string()), hasher.bh.hash_one(b"bc"));
+        assert_eq!(hasher.hash(&"abcdefghijklmn".to_string()), hasher.bh.hash_one(b"jk"));
         assert_eq!(hasher.hash(&"a".to_string()), 0);
     }
 

--- a/frozen-collections-core/src/hashers/passthrough_hasher.rs
+++ b/frozen-collections-core/src/hashers/passthrough_hasher.rs
@@ -1,18 +1,13 @@
 use crate::traits::{Hasher, Scalar};
+
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 /// A hasher that simply returns the value as the hash.
 ///
 #[doc = include_str!("../doc_snippets/private_api_warning.md")]
-#[derive(Clone, Debug)]
-pub struct PassthroughHasher {}
-
-impl PassthroughHasher {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
-    }
-}
+#[derive(Clone, Debug, Default)]
+pub struct PassthroughHasher;
 
 impl<T> Hasher<[T]> for PassthroughHasher {
     fn hash(&self, value: &[T]) -> u64 {
@@ -47,11 +42,6 @@ where
     }
 }
 
-impl Default for PassthroughHasher {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,21 +49,21 @@ mod tests {
 
     #[test]
     fn hash_string_returns_length() {
-        let hasher = PassthroughHasher::new();
+        let hasher = PassthroughHasher {};
         let value = String::from("hello");
         assert_eq!(hasher.hash(&value), 5);
     }
 
     #[test]
     fn hash_str_returns_length() {
-        let hasher = PassthroughHasher::new();
+        let hasher = PassthroughHasher {};
         let value = "world";
         assert_eq!(hasher.hash(value), 5);
     }
 
     #[test]
     fn hash_slice_returns_length() {
-        let hasher = PassthroughHasher::new();
+        let hasher = PassthroughHasher {};
         let binding = vec![1, 2, 3, 4];
         let value = binding.as_slice();
         assert_eq!(hasher.hash(value), 4);
@@ -81,14 +71,16 @@ mod tests {
 
     #[test]
     fn hash_scalar_returns_index() {
-        let hasher = PassthroughHasher::new();
+        let hasher = PassthroughHasher {};
         let index = Scalar::index(&42) as u64;
         assert_eq!(hasher.hash(&42), index);
     }
 
     #[test]
     fn default_creates_instance() {
+        #[expect(clippy::default_constructed_unit_structs, reason = "Testing Default trait")]
         let hasher = PassthroughHasher::default();
+
         assert_eq!(hasher.hash(&"default"), 7);
     }
 }

--- a/frozen-collections-core/src/hashers/right_range_hasher.rs
+++ b/frozen-collections-core/src/hashers/right_range_hasher.rs
@@ -1,7 +1,6 @@
 use crate::DefaultHashBuilder;
 use crate::traits::Hasher;
 use crate::utils::cold;
-use alloc::string::String;
 use core::hash::{BuildHasher, Hash};
 use core::ops::Range;
 
@@ -15,6 +14,7 @@ pub struct RightRangeHasher<BH = DefaultHashBuilder> {
 }
 
 impl<BH> RightRangeHasher<BH> {
+    /// Creates a new `RightRangeHasher` with the given `BuildHasher` and range.
     #[must_use]
     pub const fn new(bh: BH, range: Range<usize>) -> Self {
         Self { bh, range }
@@ -38,46 +38,31 @@ where
     }
 }
 
-impl<BH> Hasher<String> for RightRangeHasher<BH>
-where
-    BH: BuildHasher,
-{
-    #[inline]
-    fn hash(&self, value: &String) -> u64 {
-        let b = value.as_bytes();
-        if b.len() < self.range.end {
-            cold();
-            return 0;
-        }
-
-        let effective_range = value.len() - self.range.end..value.len() - self.range.start;
-        self.bh.hash_one(&b[effective_range])
-    }
-}
-
-impl<BH> Hasher<&str> for RightRangeHasher<BH>
-where
-    BH: BuildHasher,
-{
-    #[inline]
-    fn hash(&self, value: &&str) -> u64 {
-        let b = value.as_bytes();
-        if b.len() < self.range.end {
-            cold();
-            return 0;
-        }
-
-        let effective_range = value.len() - self.range.end..value.len() - self.range.start;
-        self.bh.hash_one(&b[effective_range])
-    }
-}
-
 impl<BH> Hasher<str> for RightRangeHasher<BH>
 where
     BH: BuildHasher,
 {
     #[inline]
     fn hash(&self, value: &str) -> u64 {
+        let b = value.as_bytes();
+        if b.len() < self.range.end {
+            cold();
+            return 0;
+        }
+
+        let effective_range = value.len() - self.range.end..value.len() - self.range.start;
+        self.bh.hash_one(&b[effective_range])
+    }
+}
+
+impl<AR, BH> Hasher<AR> for RightRangeHasher<BH>
+where
+    AR: AsRef<str>,
+    BH: BuildHasher,
+{
+    #[inline]
+    fn hash(&self, value: &AR) -> u64 {
+        let value = value.as_ref();
         let b = value.as_bytes();
         if b.len() < self.range.end {
             cold();
@@ -101,17 +86,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
     use alloc::vec;
     use foldhash::fast::RandomState;
 
     #[test]
     fn test_right_range_hasher_hash_slice() {
         let hasher = RightRangeHasher::new(RandomState::default(), 1..3);
-        assert_eq!(
-            hasher.hash(vec![1, 2, 3, 4].as_slice()),
-            hasher.bh.hash_one(vec![2, 3].as_slice())
-        );
+        assert_eq!(hasher.hash(vec![1, 2, 3, 4].as_slice()), hasher.bh.hash_one(vec![2, 3].as_slice()));
         assert_eq!(
             hasher.hash(vec![1, 2, 3, 4, 5, 6].as_slice()),
             hasher.bh.hash_one(vec![4, 5].as_slice())
@@ -122,14 +103,8 @@ mod tests {
     #[test]
     fn test_right_range_hasher_hash_string() {
         let hasher = RightRangeHasher::new(RandomState::default(), 3..5);
-        assert_eq!(
-            hasher.hash(&"abcdef".to_string()),
-            hasher.bh.hash_one(b"bc")
-        );
-        assert_eq!(
-            hasher.hash(&"abcdefghijklmn".to_string()),
-            hasher.bh.hash_one(b"jk")
-        );
+        assert_eq!(hasher.hash(&"abcdef".to_string()), hasher.bh.hash_one(b"bc"));
+        assert_eq!(hasher.hash(&"abcdefghijklmn".to_string()), hasher.bh.hash_one(b"jk"));
         assert_eq!(hasher.hash(&"a".to_string()), 0);
     }
 

--- a/frozen-collections-core/src/inline_maps/inline_binary_search_map.rs
+++ b/frozen-collections-core/src/inline_maps/inline_binary_search_map.rs
@@ -1,18 +1,17 @@
 use crate::maps::decl_macros::{
-    binary_search_query_funcs, debug_fn, get_disjoint_mut_fn, get_disjoint_unchecked_mut_body,
-    get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn, into_iter_mut_ref_fn, into_iter_ref_fn,
-    map_iteration_funcs, partial_eq_fn,
+    binary_search_primary_funcs, common_primary_funcs, debug_trait_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery};
-use alloc::vec::Vec;
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -33,10 +32,7 @@ pub struct InlineBinarySearchMap<K, V, const SZ: usize> {
     entries: [(K, V); SZ],
 }
 
-impl<K, V, const SZ: usize> InlineBinarySearchMap<K, V, SZ>
-where
-    K: Ord,
-{
+impl<K, V, const SZ: usize> InlineBinarySearchMap<K, V, SZ> {
     /// Creates a frozen map.
     ///
     /// This function assumes the vector is sorted according to the ordering of the [`Ord`] trait.
@@ -46,21 +42,25 @@ where
             entries: processed_entries,
         }
     }
+
+    binary_search_primary_funcs!();
+    common_primary_funcs!(const_len, entries);
 }
 
-impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineBinarySearchMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineBinarySearchMap<K, V, SZ> where Q: ?Sized + Comparable<K> {}
+
+impl<K, V, Q, const SZ: usize> MapExtras<K, V, Q> for InlineBinarySearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    get_disjoint_mut_fn!();
-    get_disjoint_unchecked_mut_fn!();
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, Q, const SZ: usize> MapQuery<K, V, Q> for InlineBinarySearchMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> MapQuery<Q, V> for InlineBinarySearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    binary_search_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> MapIteration<K, V> for InlineBinarySearchMap<K, V, SZ> {
@@ -94,41 +94,39 @@ impl<K, V, const SZ: usize> MapIteration<K, V> for InlineBinarySearchMap<K, V, S
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> Len for InlineBinarySearchMap<K, V, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, K, V, const SZ: usize> Index<&Q> for InlineBinarySearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> IntoIterator for InlineBinarySearchMap<K, V, SZ> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a InlineBinarySearchMap<K, V, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a mut InlineBinarySearchMap<K, V, SZ> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT, const N: usize> PartialEq<MT> for InlineBinarySearchMap<K, V, N>
 where
     K: Ord,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V, const N: usize> Eq for InlineBinarySearchMap<K, V, N>
@@ -143,7 +141,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -152,5 +150,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_maps/inline_dense_scalar_lookup_map.rs
+++ b/frozen-collections-core/src/inline_maps/inline_dense_scalar_lookup_map.rs
@@ -1,17 +1,17 @@
 use crate::maps::decl_macros::{
-    debug_fn, dense_scalar_lookup_query_funcs, get_disjoint_mut_fn,
-    get_disjoint_unchecked_mut_body, get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn,
-    into_iter_mut_ref_fn, into_iter_ref_fn, map_iteration_funcs, partial_eq_fn,
+    common_primary_funcs, debug_trait_funcs, dense_scalar_lookup_primary_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery, Scalar};
-use alloc::vec::Vec;
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery, Scalar};
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
+use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -33,10 +33,7 @@ pub struct InlineDenseScalarLookupMap<K, V, const SZ: usize> {
     entries: [(K, V); SZ],
 }
 
-impl<K, V, const SZ: usize> InlineDenseScalarLookupMap<K, V, SZ>
-where
-    K: Scalar,
-{
+impl<K, V, const SZ: usize> InlineDenseScalarLookupMap<K, V, SZ> {
     /// Creates a frozen map.
     ///
     /// This function assumes that `min` <= `max` and that the vector is sorted according to the
@@ -49,21 +46,25 @@ where
             entries: processed_entries,
         }
     }
+
+    dense_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(const_len, entries);
 }
 
-impl<K, V, const SZ: usize> Map<K, V, K> for InlineDenseScalarLookupMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineDenseScalarLookupMap<K, V, SZ> where Q: Scalar + Comparable<K> {}
+
+impl<K, V, Q, const SZ: usize> MapExtras<K, V, Q> for InlineDenseScalarLookupMap<K, V, SZ>
 where
-    K: Scalar,
+    Q: Scalar + Comparable<K>,
 {
-    get_disjoint_mut_fn!("Scalar");
-    get_disjoint_unchecked_mut_fn!("Scalar");
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, const SZ: usize> MapQuery<K, V, K> for InlineDenseScalarLookupMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> MapQuery<Q, V> for InlineDenseScalarLookupMap<K, V, SZ>
 where
-    K: Scalar,
+    Q: Scalar + Comparable<K>,
 {
-    dense_scalar_lookup_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> MapIteration<K, V> for InlineDenseScalarLookupMap<K, V, SZ> {
@@ -97,41 +98,39 @@ impl<K, V, const SZ: usize> MapIteration<K, V> for InlineDenseScalarLookupMap<K,
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> Len for InlineDenseScalarLookupMap<K, V, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
-impl<Q, V, const SZ: usize> Index<&Q> for InlineDenseScalarLookupMap<Q, V, SZ>
+impl<K, V, Q, const SZ: usize> Index<&Q> for InlineDenseScalarLookupMap<K, V, SZ>
 where
-    Q: Scalar,
+    Q: Comparable<K> + Scalar,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> IntoIterator for InlineDenseScalarLookupMap<K, V, SZ> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a InlineDenseScalarLookupMap<K, V, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a mut InlineDenseScalarLookupMap<K, V, SZ> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT, const SZ: usize> PartialEq<MT> for InlineDenseScalarLookupMap<K, V, SZ>
 where
     K: Scalar,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> Eq for InlineDenseScalarLookupMap<K, V, SZ>
@@ -146,7 +145,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -155,5 +154,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_maps/inline_eytzinger_search_map.rs
+++ b/frozen-collections-core/src/inline_maps/inline_eytzinger_search_map.rs
@@ -1,11 +1,10 @@
 use crate::maps::decl_macros::{
-    debug_fn, eytzinger_search_query_funcs, get_disjoint_mut_fn, get_disjoint_unchecked_mut_body,
-    get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn, into_iter_mut_ref_fn, into_iter_ref_fn,
-    map_iteration_funcs, partial_eq_fn,
+    common_primary_funcs, debug_trait_funcs, eytzinger_search_primary_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery};
-use alloc::vec::Vec;
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Comparable;
@@ -14,7 +13,7 @@ use utils::eytzinger_search_by;
 use crate::utils;
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -35,10 +34,7 @@ pub struct InlineEytzingerSearchMap<K, V, const SZ: usize> {
     entries: [(K, V); SZ],
 }
 
-impl<K, V, const SZ: usize> InlineEytzingerSearchMap<K, V, SZ>
-where
-    K: Ord,
-{
+impl<K, V, const SZ: usize> InlineEytzingerSearchMap<K, V, SZ> {
     /// Creates a frozen map.
     ///
     /// This function assumes the vector is sorted according to the ordering of the [`Ord`] trait.
@@ -48,21 +44,25 @@ where
             entries: processed_entries,
         }
     }
+
+    eytzinger_search_primary_funcs!();
+    common_primary_funcs!(const_len, entries);
 }
 
-impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineEytzingerSearchMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineEytzingerSearchMap<K, V, SZ> where Q: ?Sized + Comparable<K> {}
+
+impl<K, V, Q, const SZ: usize> MapExtras<K, V, Q> for InlineEytzingerSearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    get_disjoint_mut_fn!();
-    get_disjoint_unchecked_mut_fn!();
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, Q, const SZ: usize> MapQuery<K, V, Q> for InlineEytzingerSearchMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> MapQuery<Q, V> for InlineEytzingerSearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    eytzinger_search_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> MapIteration<K, V> for InlineEytzingerSearchMap<K, V, SZ> {
@@ -96,41 +96,39 @@ impl<K, V, const SZ: usize> MapIteration<K, V> for InlineEytzingerSearchMap<K, V
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> Len for InlineEytzingerSearchMap<K, V, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, K, V, const SZ: usize> Index<&Q> for InlineEytzingerSearchMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> IntoIterator for InlineEytzingerSearchMap<K, V, SZ> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a InlineEytzingerSearchMap<K, V, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a mut InlineEytzingerSearchMap<K, V, SZ> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT, const N: usize> PartialEq<MT> for InlineEytzingerSearchMap<K, V, N>
 where
     K: Ord,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V, const N: usize> Eq for InlineEytzingerSearchMap<K, V, N>
@@ -145,7 +143,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -154,5 +152,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_maps/inline_scan_map.rs
+++ b/frozen-collections-core/src/inline_maps/inline_scan_map.rs
@@ -1,18 +1,17 @@
 use crate::maps::decl_macros::{
-    debug_fn, get_disjoint_mut_fn, index_fn, into_iter_fn, into_iter_mut_ref_fn, into_iter_ref_fn,
-    map_iteration_funcs, partial_eq_fn, scan_query_funcs,
+    common_primary_funcs, debug_trait_funcs, get_disjoint_mut_funcs, index_trait_funcs, into_iterator_trait_funcs,
+    into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs, map_iteration_trait_funcs,
+    map_query_trait_funcs, partial_eq_trait_funcs, scan_primary_funcs,
 };
-use crate::maps::decl_macros::{get_disjoint_unchecked_mut_body, get_disjoint_unchecked_mut_fn};
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery};
-use alloc::vec::Vec;
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Equivalent;
 
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -32,10 +31,7 @@ pub struct InlineScanMap<K, V, const SZ: usize> {
     entries: [(K, V); SZ],
 }
 
-impl<K, V, const SZ: usize> InlineScanMap<K, V, SZ>
-where
-    K: Eq,
-{
+impl<K, V, const SZ: usize> InlineScanMap<K, V, SZ> {
     /// Creates a frozen map.
     #[must_use]
     pub const fn new_raw(processed_entries: [(K, V); SZ]) -> Self {
@@ -43,21 +39,25 @@ where
             entries: processed_entries,
         }
     }
+
+    scan_primary_funcs!();
+    common_primary_funcs!(const_len, entries);
 }
 
-impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineScanMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> Map<K, V, Q> for InlineScanMap<K, V, SZ> where Q: ?Sized + Equivalent<K> {}
+
+impl<K, V, Q, const SZ: usize> MapExtras<K, V, Q> for InlineScanMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Equivalent<K>,
+    Q: ?Sized + Equivalent<K>,
 {
-    get_disjoint_mut_fn!();
-    get_disjoint_unchecked_mut_fn!();
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, Q, const SZ: usize> MapQuery<K, V, Q> for InlineScanMap<K, V, SZ>
+impl<K, V, Q, const SZ: usize> MapQuery<Q, V> for InlineScanMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Equivalent<K>,
+    Q: ?Sized + Equivalent<K>,
 {
-    scan_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> MapIteration<K, V> for InlineScanMap<K, V, SZ> {
@@ -91,47 +91,45 @@ impl<K, V, const SZ: usize> MapIteration<K, V> for InlineScanMap<K, V, SZ> {
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> Len for InlineScanMap<K, V, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, K, V, const SZ: usize> Index<&Q> for InlineScanMap<K, V, SZ>
 where
-    Q: ?Sized + Eq + Equivalent<K>,
+    Q: ?Sized + Equivalent<K>,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V, const SZ: usize> IntoIterator for InlineScanMap<K, V, SZ> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a InlineScanMap<K, V, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V, const SZ: usize> IntoIterator for &'a mut InlineScanMap<K, V, SZ> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT, const N: usize> PartialEq<MT> for InlineScanMap<K, V, N>
 where
-    K: Eq,
+    K: PartialEq,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V, const N: usize> Eq for InlineScanMap<K, V, N>
 where
     K: Eq,
-    V: PartialEq,
+    V: Eq,
 {
 }
 
@@ -140,7 +138,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -149,5 +147,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_sets/inline_binary_search_set.rs
+++ b/frozen-collections-core/src/inline_sets/inline_binary_search_set.rs
@@ -1,18 +1,20 @@
 use crate::inline_maps::InlineBinarySearchMap;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    binary_search_primary_funcs, bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 use equivalent::Comparable;
 
+use crate::maps::decl_macros::len_trait_funcs;
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -38,18 +40,25 @@ impl<T, const SZ: usize> InlineBinarySearchSet<T, SZ> {
     pub const fn new(map: InlineBinarySearchMap<T, (), SZ>) -> Self {
         Self { map }
     }
+
+    binary_search_primary_funcs!();
+    common_primary_funcs!(const_len);
 }
 
-impl<T, Q, const SZ: usize> Set<T, Q> for InlineBinarySearchSet<T, SZ> where
-    Q: ?Sized + Ord + Comparable<T>
-{
-}
+impl<T, Q, const SZ: usize> Set<T, Q> for InlineBinarySearchSet<T, SZ> where Q: ?Sized + Comparable<T> {}
 
-impl<T, Q, const SZ: usize> SetQuery<T, Q> for InlineBinarySearchSet<T, SZ>
+impl<T, Q, const SZ: usize> SetExtras<T, Q> for InlineBinarySearchSet<T, SZ>
 where
-    Q: ?Sized + Ord + Comparable<T>,
+    Q: ?Sized + Comparable<T>,
 {
-    get_fn!();
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q, const SZ: usize> SetQuery<Q> for InlineBinarySearchSet<T, SZ>
+where
+    Q: ?Sized + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T, const SZ: usize> SetIteration<T> for InlineBinarySearchSet<T, SZ> {
@@ -58,61 +67,59 @@ impl<T, const SZ: usize> SetIteration<T> for InlineBinarySearchSet<T, SZ> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Len for InlineBinarySearchSet<T, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitOr<&ST> for &InlineBinarySearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitAnd<&ST> for &InlineBinarySearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitXor<&ST> for &InlineBinarySearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> Sub<&ST> for &InlineBinarySearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T, const SZ: usize> IntoIterator for InlineBinarySearchSet<T, SZ> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T, const SZ: usize> IntoIterator for &'a InlineBinarySearchSet<T, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> PartialEq<ST> for InlineBinarySearchSet<T, SZ>
 where
     T: Ord,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Eq for InlineBinarySearchSet<T, SZ> where T: Ord {}
@@ -121,7 +128,7 @@ impl<T, const SZ: usize> Debug for InlineBinarySearchSet<T, SZ>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -129,5 +136,5 @@ impl<T, const SZ: usize> Serialize for InlineBinarySearchSet<T, SZ>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_sets/inline_dense_scalar_lookup_set.rs
+++ b/frozen-collections-core/src/inline_sets/inline_dense_scalar_lookup_set.rs
@@ -1,18 +1,21 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
+use equivalent::Comparable;
 
 use crate::inline_maps::InlineDenseScalarLookupMap;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, dense_scalar_lookup_primary_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Scalar, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Scalar, Set, SetExtras, SetIteration, SetOps, SetQuery};
 
+use crate::maps::decl_macros::len_trait_funcs;
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -31,24 +34,31 @@ pub struct InlineDenseScalarLookupSet<T, const SZ: usize> {
     map: InlineDenseScalarLookupMap<T, (), SZ>,
 }
 
-impl<T, const SZ: usize> InlineDenseScalarLookupSet<T, SZ>
-where
-    T: Scalar,
-{
+impl<T, const SZ: usize> InlineDenseScalarLookupSet<T, SZ> {
     /// Creates a frozen set.
     #[must_use]
     pub const fn new(map: InlineDenseScalarLookupMap<T, (), SZ>) -> Self {
         Self { map }
     }
+
+    dense_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(const_len);
 }
 
-impl<T, const SZ: usize> Set<T, T> for InlineDenseScalarLookupSet<T, SZ> where T: Scalar {}
+impl<T, Q, const SZ: usize> Set<T, Q> for InlineDenseScalarLookupSet<T, SZ> where Q: Comparable<T> + Scalar {}
 
-impl<T, const SZ: usize> SetQuery<T, T> for InlineDenseScalarLookupSet<T, SZ>
+impl<T, Q, const SZ: usize> SetExtras<T, Q> for InlineDenseScalarLookupSet<T, SZ>
 where
-    T: Scalar,
+    Q: Scalar + Comparable<T>,
 {
-    get_fn!("Scalar");
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q, const SZ: usize> SetQuery<Q> for InlineDenseScalarLookupSet<T, SZ>
+where
+    Q: Scalar + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T, const SZ: usize> SetIteration<T> for InlineDenseScalarLookupSet<T, SZ> {
@@ -57,61 +67,59 @@ impl<T, const SZ: usize> SetIteration<T> for InlineDenseScalarLookupSet<T, SZ> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Len for InlineDenseScalarLookupSet<T, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitOr<&ST> for &InlineDenseScalarLookupSet<T, SZ>
 where
-    T: Scalar + Hash,
+    T: Hash + Scalar,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitAnd<&ST> for &InlineDenseScalarLookupSet<T, SZ>
 where
-    T: Scalar + Hash,
+    T: Hash + Scalar,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitXor<&ST> for &InlineDenseScalarLookupSet<T, SZ>
 where
-    T: Scalar + Hash,
+    T: Hash + Scalar,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> Sub<&ST> for &InlineDenseScalarLookupSet<T, SZ>
 where
-    T: Scalar + Hash,
+    T: Hash + Scalar,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T, const SZ: usize> IntoIterator for InlineDenseScalarLookupSet<T, SZ> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T, const SZ: usize> IntoIterator for &'a InlineDenseScalarLookupSet<T, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> PartialEq<ST> for InlineDenseScalarLookupSet<T, SZ>
 where
     T: Scalar,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Eq for InlineDenseScalarLookupSet<T, SZ> where T: Scalar {}
@@ -120,7 +128,7 @@ impl<T, const SZ: usize> Debug for InlineDenseScalarLookupSet<T, SZ>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -128,5 +136,5 @@ impl<T, const SZ: usize> Serialize for InlineDenseScalarLookupSet<T, SZ>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_sets/inline_eytzinger_search_set.rs
+++ b/frozen-collections-core/src/inline_sets/inline_eytzinger_search_set.rs
@@ -1,18 +1,20 @@
 use crate::inline_maps::InlineEytzingerSearchMap;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, eytzinger_search_primary_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 use equivalent::Comparable;
 
+use crate::maps::decl_macros::len_trait_funcs;
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -38,18 +40,25 @@ impl<T, const SZ: usize> InlineEytzingerSearchSet<T, SZ> {
     pub const fn new(map: InlineEytzingerSearchMap<T, (), SZ>) -> Self {
         Self { map }
     }
+
+    eytzinger_search_primary_funcs!();
+    common_primary_funcs!(const_len);
 }
 
-impl<T, Q, const SZ: usize> Set<T, Q> for InlineEytzingerSearchSet<T, SZ> where
-    Q: ?Sized + Ord + Comparable<T>
-{
-}
+impl<T, Q, const SZ: usize> Set<T, Q> for InlineEytzingerSearchSet<T, SZ> where Q: ?Sized + Comparable<T> {}
 
-impl<T, Q, const SZ: usize> SetQuery<T, Q> for InlineEytzingerSearchSet<T, SZ>
+impl<T, Q, const SZ: usize> SetExtras<T, Q> for InlineEytzingerSearchSet<T, SZ>
 where
-    Q: ?Sized + Ord + Comparable<T>,
+    Q: ?Sized + Comparable<T>,
 {
-    get_fn!();
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q, const SZ: usize> SetQuery<Q> for InlineEytzingerSearchSet<T, SZ>
+where
+    Q: ?Sized + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T, const SZ: usize> SetIteration<T> for InlineEytzingerSearchSet<T, SZ> {
@@ -58,61 +67,59 @@ impl<T, const SZ: usize> SetIteration<T> for InlineEytzingerSearchSet<T, SZ> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Len for InlineEytzingerSearchSet<T, SZ> {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitOr<&ST> for &InlineEytzingerSearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitAnd<&ST> for &InlineEytzingerSearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitXor<&ST> for &InlineEytzingerSearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> Sub<&ST> for &InlineEytzingerSearchSet<T, SZ>
 where
-    T: Hash + Eq + Ord + Clone,
+    T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T, const SZ: usize> IntoIterator for InlineEytzingerSearchSet<T, SZ> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T, const SZ: usize> IntoIterator for &'a InlineEytzingerSearchSet<T, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> PartialEq<ST> for InlineEytzingerSearchSet<T, SZ>
 where
     T: Ord,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Eq for InlineEytzingerSearchSet<T, SZ> where T: Ord {}
@@ -121,7 +128,7 @@ impl<T, const SZ: usize> Debug for InlineEytzingerSearchSet<T, SZ>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -129,5 +136,5 @@ impl<T, const SZ: usize> Serialize for InlineEytzingerSearchSet<T, SZ>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_sets/inline_scan_set.rs
+++ b/frozen-collections-core/src/inline_sets/inline_scan_set.rs
@@ -1,10 +1,11 @@
 use crate::inline_maps::InlineScanMap;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, into_iterator_ref_trait_funcs,
+    into_iterator_trait_funcs, partial_eq_trait_funcs, scan_primary_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
@@ -12,7 +13,7 @@ use equivalent::Equivalent;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -37,15 +38,25 @@ impl<T, const SZ: usize> InlineScanSet<T, SZ> {
     pub const fn new(map: InlineScanMap<T, (), SZ>) -> Self {
         Self { map }
     }
+
+    scan_primary_funcs!();
+    common_primary_funcs!(const_len);
 }
 
-impl<T, Q, const SZ: usize> Set<T, Q> for InlineScanSet<T, SZ> where Q: ?Sized + Eq + Equivalent<T> {}
+impl<T, Q, const SZ: usize> Set<T, Q> for InlineScanSet<T, SZ> where Q: ?Sized + Equivalent<T> {}
 
-impl<T, Q, const SZ: usize> SetQuery<T, Q> for InlineScanSet<T, SZ>
+impl<T, Q, const SZ: usize> SetExtras<T, Q> for InlineScanSet<T, SZ>
 where
-    Q: ?Sized + Eq + Equivalent<T>,
+    Q: ?Sized + Equivalent<T>,
 {
-    get_fn!();
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q, const SZ: usize> SetQuery<Q> for InlineScanSet<T, SZ>
+where
+    Q: ?Sized + Equivalent<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T, const SZ: usize> SetIteration<T> for InlineScanSet<T, SZ> {
@@ -54,7 +65,7 @@ impl<T, const SZ: usize> SetIteration<T> for InlineScanSet<T, SZ> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Len for InlineScanSet<T, SZ> {
@@ -68,7 +79,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitAnd<&ST> for &InlineScanSet<T, SZ>
@@ -76,7 +87,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> BitXor<&ST> for &InlineScanSet<T, SZ>
@@ -84,7 +95,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> Sub<&ST> for &InlineScanSet<T, SZ>
@@ -92,23 +103,23 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T, const SZ: usize> IntoIterator for InlineScanSet<T, SZ> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T, const SZ: usize> IntoIterator for &'a InlineScanSet<T, SZ> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST, const SZ: usize> PartialEq<ST> for InlineScanSet<T, SZ>
 where
-    T: Eq,
-    ST: Set<T>,
+    T: PartialEq,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T, const SZ: usize> Eq for InlineScanSet<T, SZ> where T: Eq {}
@@ -117,7 +128,7 @@ impl<T, const SZ: usize> Debug for InlineScanSet<T, SZ>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -125,5 +136,5 @@ impl<T, const SZ: usize> Serialize for InlineScanSet<T, SZ>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/inline_sets/inline_sparse_scalar_lookup_set.rs
+++ b/frozen-collections-core/src/inline_sets/inline_sparse_scalar_lookup_set.rs
@@ -1,20 +1,20 @@
 use crate::inline_maps::InlineSparseScalarLookupMap;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, into_iterator_ref_trait_funcs,
+    into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs, set_query_trait_funcs,
+    sparse_scalar_lookup_primary_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{
-    CollectionMagnitude, Len, MapIteration, MapQuery, Scalar, Set, SetIteration, SetOps, SetQuery,
-    SmallCollection,
-};
+use crate::traits::{CollectionMagnitude, Len, Scalar, Set, SetExtras, SetIteration, SetOps, SetQuery, SmallCollection};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
+use equivalent::Comparable;
 
+use crate::maps::decl_macros::len_trait_funcs;
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -31,38 +31,50 @@ use {
 /// - `SZ`: The number of entries in the set.
 /// - `LTSZ`: The number of entries in the lookup table.
 #[derive(Clone)]
-pub struct InlineSparseScalarLookupSet<T, const SZ: usize, const LTSZ: usize, CM = SmallCollection>
-{
+pub struct InlineSparseScalarLookupSet<T, const SZ: usize, const LTSZ: usize, CM = SmallCollection> {
     map: InlineSparseScalarLookupMap<T, (), SZ, LTSZ, CM>,
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> InlineSparseScalarLookupSet<T, SZ, LTSZ, CM> {
+impl<T, const SZ: usize, const LTSZ: usize, CM> InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    CM: CollectionMagnitude,
+{
     /// Creates a frozen set.
     #[must_use]
     pub const fn new(map: InlineSparseScalarLookupMap<T, (), SZ, LTSZ, CM>) -> Self {
         Self { map }
     }
+
+    sparse_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(const_len);
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> Set<T, T>
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, Q, const SZ: usize, const LTSZ: usize, CM> Set<T, Q> for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     CM: CollectionMagnitude,
-    T: Scalar,
+    Q: Comparable<T> + Scalar,
 {
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> SetQuery<T, T>
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, Q, const SZ: usize, const LTSZ: usize, CM> SetExtras<T, Q> for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     CM: CollectionMagnitude,
-    T: Scalar,
+    Q: Scalar + Comparable<T>,
 {
-    get_fn!("Scalar");
+    set_extras_trait_funcs!();
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> SetIteration<T>
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, Q, const SZ: usize, const LTSZ: usize, CM> SetQuery<Q> for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    CM: CollectionMagnitude,
+    Q: Scalar + Comparable<T>,
+{
+    set_query_trait_funcs!();
+}
+
+impl<T, const SZ: usize, const LTSZ: usize, CM> SetIteration<T> for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    CM: CollectionMagnitude,
 {
     type Iterator<'a>
         = Iter<'a, T>
@@ -70,77 +82,72 @@ impl<T, const SZ: usize, const LTSZ: usize, CM> SetIteration<T>
         T: 'a,
         CM: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> Len
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, const SZ: usize, const LTSZ: usize, CM> Len for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    CM: CollectionMagnitude,
 {
-    fn len(&self) -> usize {
-        SZ
-    }
+    len_trait_funcs!();
 }
 
-impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitOr<&ST>
-    for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitOr<&ST> for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Scalar + Hash,
     ST: Set<T>,
     CM: CollectionMagnitude,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
-impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitAnd<&ST>
-    for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitAnd<&ST> for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Scalar + Hash,
     ST: Set<T>,
     CM: CollectionMagnitude,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
-impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitXor<&ST>
-    for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, ST, const SZ: usize, const LTSZ: usize, CM> BitXor<&ST> for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Scalar + Hash,
     ST: Set<T>,
     CM: CollectionMagnitude,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
-impl<T, ST, const SZ: usize, const LTSZ: usize, CM> Sub<&ST>
-    for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, ST, const SZ: usize, const LTSZ: usize, CM> Sub<&ST> for &InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Scalar + Hash,
     ST: Set<T>,
     CM: CollectionMagnitude,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> IntoIterator
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
-{
-    into_iter_fn!();
-}
-
-impl<'a, T, const SZ: usize, const LTSZ: usize, CM> IntoIterator
-    for &'a InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
-{
-    into_iter_ref_fn!();
-}
-
-impl<T, ST, const SZ: usize, const LTSZ: usize, CM> PartialEq<ST>
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, const SZ: usize, const LTSZ: usize, CM> IntoIterator for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
-    T: Scalar,
-    ST: Set<T>,
     CM: CollectionMagnitude,
 {
-    partial_eq_fn!();
+    into_iterator_trait_funcs!();
+}
+
+impl<'a, T, const SZ: usize, const LTSZ: usize, CM> IntoIterator for &'a InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    CM: CollectionMagnitude,
+{
+    into_iterator_ref_trait_funcs!();
+}
+
+impl<T, ST, const SZ: usize, const LTSZ: usize, CM> PartialEq<ST> for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+where
+    ST: SetQuery<T>,
+    CM: CollectionMagnitude,
+{
+    partial_eq_trait_funcs!();
 }
 
 impl<T, const SZ: usize, const LTSZ: usize, CM> Eq for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
@@ -150,19 +157,19 @@ where
 {
 }
 
-impl<T, const SZ: usize, const LTSZ: usize, CM> Debug
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, const SZ: usize, const LTSZ: usize, CM> Debug for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Debug,
+    CM: CollectionMagnitude,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
-impl<T, const SZ: usize, const LTSZ: usize, CM> Serialize
-    for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
+impl<T, const SZ: usize, const LTSZ: usize, CM> Serialize for InlineSparseScalarLookupSet<T, SZ, LTSZ, CM>
 where
     T: Serialize,
+    CM: CollectionMagnitude,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/lib.rs
+++ b/frozen-collections-core/src/lib.rs
@@ -10,7 +10,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
-extern crate core;
 
 mod analyzers;
 pub mod fz_maps;

--- a/frozen-collections-core/src/macros/derive_scalar_macro.rs
+++ b/frozen-collections-core/src/macros/derive_scalar_macro.rs
@@ -1,31 +1,26 @@
-use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Error, Fields};
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Implementation logic for the `Scalar` derive macro.
 ///
 /// # Errors
 ///
 /// Bad things happen to bad input
-#[allow(clippy::module_name_repetitions)]
 pub fn derive_scalar_macro(args: TokenStream) -> syn::Result<TokenStream> {
     let input: DeriveInput = syn::parse2(args)?;
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let Data::Enum(variants) = &input.data else {
-        return Err(Error::new_spanned(
-            name,
-            "Scalar can only be used with enums",
-        ));
+        return Err(Error::new_spanned(name, "Scalar can only be used with enums"));
     };
 
     if variants.variants.is_empty() {
-        return Err(Error::new_spanned(
-            name,
-            "Scalar can only be used with non-empty enums",
-        ));
+        return Err(Error::new_spanned(name, "Scalar can only be used with non-empty enums"));
     }
 
     for v in &variants.variants {
@@ -67,7 +62,6 @@ pub fn derive_scalar_macro(args: TokenStream) -> syn::Result<TokenStream> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
 
     #[test]
     fn basic() {
@@ -93,10 +87,7 @@ mod tests {
             }
         ));
 
-        assert_eq!(
-            "Scalar can only be used with enums",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("Scalar can only be used with enums", r.unwrap_err().to_string());
     }
 
     #[test]
@@ -105,10 +96,7 @@ mod tests {
             enum Color {}
         ));
 
-        assert_eq!(
-            "Scalar can only be used with non-empty enums",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("Scalar can only be used with non-empty enums", r.unwrap_err().to_string());
     }
 
     #[test]

--- a/frozen-collections-core/src/macros/macro_api.rs
+++ b/frozen-collections-core/src/macros/macro_api.rs
@@ -2,9 +2,11 @@ use crate::emit::CollectionEmitter;
 use crate::macros::parsing::map::Map;
 use crate::macros::parsing::set::Set;
 use crate::macros::processor::{MacroKind, process};
-use alloc::string::ToString;
 use proc_macro2::TokenStream;
 use syn::parse2;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 /// Implementation logic for the `fz_hash_map!` macro.
 ///
@@ -124,7 +126,6 @@ fn fz_set_macro(args: TokenStream, macro_kind: MacroKind) -> syn::Result<TokenSt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
     use proc_macro2::Delimiter::Brace;
     use proc_macro2::{Group, TokenTree};
     use quote::{ToTokens, TokenStreamExt, quote};
@@ -151,10 +152,7 @@ mod tests {
             { 123iXXX, 234iXXX }
         ));
 
-        assert_eq!(
-            "unknown suffix iXXX for scalar value",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("unknown suffix iXXX for scalar value", r.unwrap_err().to_string());
     }
 
     #[test]
@@ -163,10 +161,7 @@ mod tests {
             { 1i8, 2i16 }
         ));
 
-        assert_eq!(
-            "incompatible scalar literal type",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("incompatible scalar literal type", r.unwrap_err().to_string());
     }
 
     #[test]
@@ -175,28 +170,19 @@ mod tests {
             { 123.0, 234.0 }
         ));
 
-        assert_eq!(
-            "invalid literal, expecting a scalar or string value",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("invalid literal, expecting a scalar or string value", r.unwrap_err().to_string());
 
         let r = fz_string_set_macro(quote!(
             { 1, 2 }
         ));
 
-        assert_eq!(
-            "string macro cannot contain scalar keys",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("string macro cannot contain scalar keys", r.unwrap_err().to_string());
 
         let r = fz_scalar_set_macro(quote!(
             { "1", "2" }
         ));
 
-        assert_eq!(
-            "scalar macro cannot contain string keys",
-            r.unwrap_err().to_string()
-        );
+        assert_eq!("scalar macro cannot contain string keys", r.unwrap_err().to_string());
     }
 
     #[test]
@@ -240,10 +226,7 @@ mod tests {
         check_impl(":: InlineScanSet", quote!({ "1", "2", "3", }));
         check_impl(":: InlineHashSet", quote!({ "1", "2", "3", "4" }));
 
-        check_impl(
-            ":: BridgeHasher",
-            quote!({ "1", "2", "3", "4", "5", "6", "7" }),
-        );
+        check_impl(":: BridgeHasher", quote!({ "1", "2", "3", "4", "5", "6", "7" }));
 
         check_impl(
             ":: PassthroughHasher",
@@ -271,10 +254,7 @@ mod tests {
         check_impl(":: InlineDenseScalarLookupSet", quote!({ 1, 2, 3, }));
         check_impl(":: InlineSparseScalarLookupSet", quote!({ 1, 2, 3, 4, 6 }));
         check_impl(":: InlineScanSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000 }));
-        check_impl(
-            ":: InlineHashSet",
-            quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }),
-        );
+        check_impl(":: InlineHashSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }));
 
         check_impl(":: InlineScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7, 8 }));
@@ -290,19 +270,13 @@ mod tests {
         check_impl(":: InlineDenseScalarLookupSet", quote!({ 1, 2, 3, }));
         check_impl(":: InlineSparseScalarLookupSet", quote!({ 1, 2, 3, 4, 6 }));
         check_impl(":: InlineScanSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000 }));
-        check_impl(
-            ":: InlineHashSet",
-            quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }),
-        );
+        check_impl(":: InlineHashSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }));
 
         check_impl(":: InlineScanSet", quote!({ "1", "2", "3", }));
         check_impl(":: InlineHashSet", quote!({ "1", "2", "3", "4" }));
 
         check_impl(":: InlineScanSet", quote!({ Foo(1), Foo(2), Foo(3),}));
-        check_impl(
-            ":: EytzingerSearchSet",
-            quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }),
-        );
+        check_impl(":: EytzingerSearchSet", quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }));
 
         check_impl(":: InlineScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7, 8 }));
@@ -321,10 +295,7 @@ mod tests {
         check_impl(":: InlineDenseScalarLookupSet", quote!({ 1, 2, 3, }));
         check_impl(":: InlineSparseScalarLookupSet", quote!({ 1, 2, 3, 4, 6 }));
         check_impl(":: InlineScanSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000 }));
-        check_impl(
-            ":: InlineHashSet",
-            quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }),
-        );
+        check_impl(":: InlineHashSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }));
 
         check_impl(":: InlineScanSet", quote!({ "1", "2", "3", }));
         check_impl(":: InlineHashSet", quote!({ "1", "2", "3", "4" }));
@@ -341,14 +312,10 @@ mod tests {
 
     #[test]
     fn test_scalar_suffixes() {
-        let r = fz_scalar_set_macro(quote!({ 1i8, 2, 3, 4, 5, 6 }))
-            .unwrap()
-            .to_string();
+        let r = fz_scalar_set_macro(quote!({ 1i8, 2, 3, 4, 5, 6 })).unwrap().to_string();
         assert!(r.contains("1i8"));
 
-        let r = fz_scalar_set_macro(quote!({ 1, 2, 3, 4, 5, 6 }))
-            .unwrap()
-            .to_string();
+        let r = fz_scalar_set_macro(quote!({ 1, 2, 3, 4, 5, 6 })).unwrap().to_string();
         assert!(!r.contains("1i8"));
         assert!(r.contains("1i32"));
     }

--- a/frozen-collections-core/src/macros/parsing/map.rs
+++ b/frozen-collections-core/src/macros/parsing/map.rs
@@ -3,7 +3,7 @@ use crate::macros::parsing::short_form_map::ShortFormMap;
 use syn::parse::Parse;
 use syn::{Token, Visibility};
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "This is fine")]
 pub enum Map {
     Short(ShortFormMap),
     Long(LongFormMap),

--- a/frozen-collections-core/src/macros/parsing/mod.rs
+++ b/frozen-collections-core/src/macros/parsing/mod.rs
@@ -1,8 +1,8 @@
-pub mod entry;
-pub mod long_form_map;
-pub mod long_form_set;
-pub mod map;
-pub mod payload;
-pub mod set;
-pub mod short_form_map;
-pub mod short_form_set;
+pub(super) mod entry;
+pub(super) mod long_form_map;
+pub(super) mod long_form_set;
+pub(super) mod map;
+pub(super) mod payload;
+pub(super) mod set;
+pub(super) mod short_form_map;
+pub(super) mod short_form_set;

--- a/frozen-collections-core/src/macros/parsing/payload.rs
+++ b/frozen-collections-core/src/macros/parsing/payload.rs
@@ -1,15 +1,16 @@
 use crate::macros::parsing::entry::Entry;
 use crate::macros::parsing::long_form_set::SetEntry;
-use alloc::vec::Vec;
 use syn::parse::Parse;
 use syn::{Token, braced};
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Data associated with a frozen collection macro.
 pub struct Payload {
     pub entries: Vec<Entry>,
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub fn parse_set_payload(input: syn::parse::ParseStream) -> syn::Result<Payload> {
     // { value, value, ... };
     let content;
@@ -19,24 +20,17 @@ pub fn parse_set_payload(input: syn::parse::ParseStream) -> syn::Result<Payload>
         entries: content
             .parse_terminated(SetEntry::parse, Token![,])?
             .into_iter()
-            .map(|x| Entry {
-                key: x.value,
-                value: None,
-            })
+            .map(|x| Entry { key: x.value, value: None })
             .collect(),
     })
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub fn parse_map_payload(input: syn::parse::ParseStream) -> syn::Result<Payload> {
     // { key: value, key: value, ... };
     let content;
     _ = braced!(content in input);
 
     Ok(Payload {
-        entries: content
-            .parse_terminated(Entry::parse, Token![,])?
-            .into_iter()
-            .collect(),
+        entries: content.parse_terminated(Entry::parse, Token![,])?.into_iter().collect(),
     })
 }

--- a/frozen-collections-core/src/macros/parsing/set.rs
+++ b/frozen-collections-core/src/macros/parsing/set.rs
@@ -3,7 +3,7 @@ use crate::macros::parsing::short_form_set::ShortFormSet;
 use syn::parse::Parse;
 use syn::{Token, Visibility};
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant, reason = "Large is in the eye of the beholder, this is just fine")]
 pub enum Set {
     Short(ShortFormSet),
     Long(LongFormSet),

--- a/frozen-collections-core/src/maps/binary_search_map.rs
+++ b/frozen-collections-core/src/maps/binary_search_map.rs
@@ -1,20 +1,21 @@
 use crate::maps::decl_macros::{
-    binary_search_query_funcs, debug_fn, get_disjoint_mut_fn, get_disjoint_unchecked_mut_body,
-    get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn, into_iter_mut_ref_fn, into_iter_ref_fn,
-    map_iteration_funcs, partial_eq_fn,
+    binary_search_primary_funcs, common_primary_funcs, debug_trait_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery};
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
 use crate::utils::dedup_by_keep_last;
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Comparable;
 
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::vec::Vec};
+
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -30,13 +31,13 @@ pub struct BinarySearchMap<K, V> {
     entries: Box<[(K, V)]>,
 }
 
-impl<K, V> BinarySearchMap<K, V>
-where
-    K: Ord,
-{
+impl<K, V> BinarySearchMap<K, V> {
     /// Creates a frozen map.
     #[must_use]
-    pub fn new(mut entries: Vec<(K, V)>) -> Self {
+    pub fn new(mut entries: Vec<(K, V)>) -> Self
+    where
+        K: Ord,
+    {
         entries.sort_by(|x, y| x.0.cmp(&y.0));
         dedup_by_keep_last(&mut entries, |x, y| x.0.eq(&y.0));
         Self::new_raw(entries)
@@ -49,29 +50,31 @@ where
             entries: processed_entries.into_boxed_slice(),
         }
     }
+
+    binary_search_primary_funcs!();
+    common_primary_funcs!(non_const_len, entries);
 }
 
 impl<K, V> Default for BinarySearchMap<K, V> {
     fn default() -> Self {
-        Self {
-            entries: Box::default(),
-        }
+        Self { entries: Box::default() }
     }
 }
 
-impl<K, V, Q> Map<K, V, Q> for BinarySearchMap<K, V>
+impl<K, V, Q> Map<K, V, Q> for BinarySearchMap<K, V> where Q: ?Sized + Comparable<K> {}
+
+impl<K, V, Q> MapExtras<K, V, Q> for BinarySearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    get_disjoint_mut_fn!();
-    get_disjoint_unchecked_mut_fn!();
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, Q> MapQuery<K, V, Q> for BinarySearchMap<K, V>
+impl<K, V, Q> MapQuery<Q, V> for BinarySearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    binary_search_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V> MapIteration<K, V> for BinarySearchMap<K, V> {
@@ -105,41 +108,39 @@ impl<K, V> MapIteration<K, V> for BinarySearchMap<K, V> {
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V> Len for BinarySearchMap<K, V> {
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, K, V> Index<&Q> for BinarySearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V> IntoIterator for BinarySearchMap<K, V> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a BinarySearchMap<K, V> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a mut BinarySearchMap<K, V> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT> PartialEq<MT> for BinarySearchMap<K, V>
 where
     K: Ord,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V> Eq for BinarySearchMap<K, V>
@@ -154,7 +155,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -163,5 +164,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/maps/decl_macros.rs
+++ b/frozen-collections-core/src/maps/decl_macros.rs
@@ -1,88 +1,416 @@
-macro_rules! get_disjoint_mut_fn {
-    ("Scalar") => {
-        fn get_disjoint_mut<const N: usize>(&mut self, keys: [&K; N]) -> [Option<&mut V>; N] {
-            if crate::utils::has_duplicates_with_hasher(
-                &keys,
-                &crate::hashers::PassthroughHasher::default(),
-            ) {
-                crate::utils::cold();
-                panic!("duplicate keys found");
-            }
-
-            unsafe { self.get_disjoint_unchecked_mut(keys) }
-        }
-    };
-
-    ("Hash") => {
-        fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
-            if crate::utils::has_duplicates_with_hasher(&keys, &self.hasher) {
-                crate::utils::cold();
-                panic!("duplicate keys found");
-            }
-
-            unsafe { self.get_disjoint_unchecked_mut(keys) }
-        }
-    };
-
+macro_rules! binary_search_primary_funcs {
     () => {
-        fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
-            if crate::utils::has_duplicates_slow(&keys) {
-                crate::utils::cold();
-                panic!("duplicate keys found");
-            }
+        #[doc = include_str!("../doc_snippets/get.md")]
+        #[inline]
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            self.entries
+                .binary_search_by(|entry| key.compare(&entry.0).reverse())
+                .map(|index| {
+                    // SAFETY: We are guaranteed that the index is valid because binary_search_by returns an in-range index
+                    let entry = unsafe { self.entries.get_unchecked(index) };
+                    &entry.1
+                })
+                .ok()
+        }
 
-            unsafe { self.get_disjoint_unchecked_mut(keys) }
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
+        #[inline]
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            self.entries
+                .binary_search_by(|entry| key.compare(&entry.0).reverse())
+                .map(|index| {
+                    // SAFETY: We are guaranteed that the index is valid because binary_search_by returns an in-range index
+                    let entry = unsafe { self.entries.get_unchecked_mut(index) };
+                    &mut entry.1
+                })
+                .ok()
+        }
+
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
+        #[inline]
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            self.entries
+                .binary_search_by(|entry| key.compare(&entry.0).reverse())
+                .map(|index| {
+                    // SAFETY: We are guaranteed that the index is valid because binary_search_by returns an in-range index
+                    let entry = unsafe { self.entries.get_unchecked(index) };
+                    (&entry.0, &entry.1)
+                })
+                .ok()
+        }
+
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            self.get(key).is_some()
+        }
+
+        get_disjoint_mut_funcs!("Ord");
+    };
+}
+
+macro_rules! common_primary_funcs {
+    ($const_len:ident, $($entries:ident)+) => {
+        #[doc = include_str!("../doc_snippets/iter.md")]
+        #[must_use]
+        pub fn iter(&self) -> Iter<'_, K, V> {
+            Iter::new(&self$(. $entries)+)
+        }
+
+        #[doc = include_str!("../doc_snippets/iter_mut.md")]
+        #[must_use]
+        pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+            IterMut::new(self$(. $entries)+.as_mut())
+        }
+
+        #[must_use]
+        fn into_iter(self) -> IntoIter<K, V> {
+            IntoIter::new(self$(. $entries)+.into())
+        }
+
+        #[doc = include_str!("../doc_snippets/keys.md")]
+        #[must_use]
+        pub fn keys(&self) -> Keys<'_, K, V> {
+            Keys::new(&self$(. $entries)+)
+        }
+
+        #[doc = include_str!("../doc_snippets/into_keys.md")]
+        #[must_use]
+        pub fn into_keys(self) -> IntoKeys<K, V> {
+            // NOTE: this allocates and copies everything into a vector for the sake of iterating the vector.
+            // This is the best I could come up with, let me know if you see a way around the need to copy.
+            IntoKeys::new(alloc::vec::Vec::from(self$(. $entries)+).into_boxed_slice())
+        }
+
+        #[doc = include_str!("../doc_snippets/values.md")]
+        #[must_use]
+        pub fn values(&self) -> Values<'_, K, V> {
+            Values::new(&self$(. $entries)+)
+        }
+
+        #[doc = include_str!("../doc_snippets/values_mut.md")]
+        #[must_use]
+        pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+            ValuesMut::new(self$(. $entries)+.as_mut())
+        }
+
+        #[doc = include_str!("../doc_snippets/into_values.md")]
+        #[must_use]
+        pub fn into_values(self) -> IntoValues<K, V> {
+            // NOTE: this allocates and copies everything into a vector for the sake of iterating the vector.
+            // This is the best I could come up with, let me know if you see a way around the need to copy.
+            IntoValues::new(alloc::vec::Vec::from(self$(. $entries)+).into_boxed_slice())
+        }
+
+        common_primary_funcs!(@len $const_len);
+    };
+
+    (@len const_len) => {
+        #[doc = include_str!("../doc_snippets/len.md")]
+        #[inline]
+        #[must_use]
+        pub const fn len(&self) -> usize {
+            self.entries.len()
+        }
+
+        #[doc = include_str!("../doc_snippets/is_empty.md")]
+        #[inline]
+        #[must_use]
+        pub const fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+    };
+
+    (@len non_const_len) => {
+        #[doc = include_str!("../doc_snippets/len.md")]
+        #[inline]
+        #[must_use]
+        pub fn len(&self) -> usize {
+            self.entries.len()
+        }
+
+        #[doc = include_str!("../doc_snippets/is_empty.md")]
+        #[inline]
+        #[must_use]
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
         }
     };
 }
 
-macro_rules! get_disjoint_unchecked_mut_fn {
-    ("Scalar") => {
-        unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-            &mut self,
-            keys: [&K; N],
-        ) -> [Option<&mut V>; N] {
-            get_disjoint_unchecked_mut_body!(self, keys);
-        }
-    };
-
-    ("Hash") => {
-        unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-            &mut self,
-            keys: [&Q; N],
-        ) -> [Option<&mut V>; N] {
-            get_disjoint_unchecked_mut_body!(self, keys);
-        }
-    };
-
+macro_rules! debug_trait_funcs {
     () => {
-        unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-            &mut self,
-            keys: [&Q; N],
-        ) -> [Option<&mut V>; N] {
-            get_disjoint_unchecked_mut_body!(self, keys);
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+            let pairs = self.iter().map(|x| (x.0, x.1));
+            f.debug_map().entries(pairs).finish()
         }
     };
 }
 
-macro_rules! get_disjoint_unchecked_mut_body {
-    ($self:ident, $keys:ident) => {
-        let mut result: core::mem::MaybeUninit<[Option<&mut V>; N]> =
-            core::mem::MaybeUninit::uninit();
-        let p = result.as_mut_ptr();
-        let x: *mut Self = $self;
+macro_rules! dense_scalar_lookup_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get.md")]
+        #[inline]
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            let index = key.index();
+            (index >= self.min && index <= self.max).then(|| {
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let entry = unsafe { self.entries.get_unchecked(index - self.min) };
+                &entry.1
+            })
+        }
 
-        unsafe {
-            for (i, key) in $keys.iter().enumerate() {
-                (*p)[i] = (*x).get_mut(*key);
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
+        #[inline]
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            let index = key.index();
+            (index >= self.min && index <= self.max).then(|| {
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let entry = unsafe { self.entries.get_unchecked_mut(index - self.min) };
+                &mut entry.1
+            })
+        }
+
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
+        #[inline]
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            let index = key.index();
+            (index >= self.min && index <= self.max).then(|| {
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let entry = unsafe { self.entries.get_unchecked(index - self.min) };
+                (&entry.0, &entry.1)
+            })
+        }
+
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            self.get(key).is_some()
+        }
+
+        get_disjoint_mut_funcs!("Scalar");
+    };
+}
+
+macro_rules! eytzinger_search_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get.md")]
+        #[inline]
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            if let Some(index) = eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse()) {
+                // SAFETY: We are guaranteed that the index is valid because eytzinger_search_by returns an in-range index
+                let entry = unsafe { self.entries.get_unchecked(index) };
+                Some(&entry.1)
+            } else {
+                None
             }
+        }
 
-            return result.assume_init();
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
+        #[inline]
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            if let Some(index) = eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse()) {
+                // SAFETY: We are guaranteed that the index is valid because eytzinger_search_by returns an in-range index
+                let entry = unsafe { self.entries.get_unchecked_mut(index) };
+                Some(&mut entry.1)
+            } else {
+                None
+            }
+        }
+
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
+        #[inline]
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            if let Some(index) = eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse()) {
+                // SAFETY: We are guaranteed that the index is valid because eytzinger_search_by returns an in-range index
+                let entry = unsafe { self.entries.get_unchecked(index) };
+                Some((&entry.0, &entry.1))
+            } else {
+                None
+            }
+        }
+
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            self.get(key).is_some()
+        }
+
+        get_disjoint_mut_funcs!("Ord");
+    };
+}
+
+macro_rules! get_disjoint_mut_funcs {
+    ("Ord") => {
+        #[doc = include_str!("../doc_snippets/get_disjoint_mut.md")]
+        pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Eq + Comparable<K>,
+        {
+            get_disjoint_mut_funcs!(@safe_body, self, keys);
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_unchecked_mut.md")]
+        pub unsafe fn get_disjoint_unchecked_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Comparable<K>,
+        {
+            get_disjoint_mut_funcs!(@unsafe_body, self, keys);
+        }
+    };
+
+    ("Scalar") => {
+        #[doc = include_str!("../doc_snippets/get_disjoint_mut.md")]
+        pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: Eq + Comparable<K> + Scalar,
+        {
+            get_disjoint_mut_funcs!(@safe_body, self, keys);
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_unchecked_mut.md")]
+        pub unsafe fn get_disjoint_unchecked_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            get_disjoint_mut_funcs!(@unsafe_body, self, keys);
+        }
+    };
+
+    (@safe_body, $self:ident, $keys:ident) => {
+        if crate::utils::has_duplicates(&$keys) {
+            crate::utils::cold();
+            panic!("duplicate keys found");
+        }
+
+        // SAFETY: We've validated that the caller isn't asking for duplicate keys
+        return unsafe { $self.get_disjoint_unchecked_mut($keys) };
+    };
+
+    (@unsafe_body, $self:ident, $keys:ident) => {
+        let ptrs: [Option<::core::ptr::NonNull<V>>; N] = ::core::array::from_fn(|i| {
+            $self.get_mut($keys[i]).map(|value| {
+                let v = value as *mut V;
+                ::core::ptr::NonNull::new(v).unwrap()
+            })
+        });
+
+        return ptrs.map(|ptr| ptr.map(|mut ptr|
+            // SAFETY: pointers all safely acquired above
+            unsafe { ptr.as_mut() }
+        ));
+    };
+}
+
+macro_rules! hash_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get.md")]
+        #[inline]
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: ?Sized + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            self.entries
+                .find(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
+                .map(|(_, v)| v)
+        }
+
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
+        #[inline]
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: ?Sized + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            self.entries
+                .find_mut(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
+                .map(|(_, v)| v)
+        }
+
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
+        #[inline]
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: ?Sized + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            self.entries
+                .find(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
+                .map(|(k, v)| (k, v))
+        }
+
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: ?Sized + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            self.get(key).is_some()
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_mut.md")]
+        pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Eq + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            get_disjoint_mut_funcs!(@safe_body, self, keys);
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_unchecked_mut.md")]
+        pub unsafe fn get_disjoint_unchecked_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Equivalent<K>,
+            H: Hasher<Q>,
+        {
+            get_disjoint_mut_funcs!(@unsafe_body, self, keys);
         }
     };
 }
 
-macro_rules! index_fn {
+macro_rules! index_trait_funcs {
     () => {
         type Output = V;
 
@@ -93,29 +421,18 @@ macro_rules! index_fn {
     };
 }
 
-macro_rules! into_iter_fn {
-    ($($entries:ident)+) => {
+macro_rules! into_iterator_trait_funcs {
+    () => {
         type Item = (K, V);
         type IntoIter = IntoIter<K, V>;
 
         fn into_iter(self) -> Self::IntoIter {
-            IntoIter::new(self$(. $entries)+.into())
+            self.into_iter()
         }
     };
 }
 
-macro_rules! into_iter_ref_fn {
-    () => {
-        type Item = (&'a K, &'a V);
-        type IntoIter = Iter<'a, K, V>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            self.iter()
-        }
-    };
-}
-
-macro_rules! into_iter_mut_ref_fn {
+macro_rules! into_iterator_trait_mut_ref_funcs {
     () => {
         type Item = (&'a K, &'a mut V);
         type IntoIter = IterMut<'a, K, V>;
@@ -126,31 +443,197 @@ macro_rules! into_iter_mut_ref_fn {
     };
 }
 
-macro_rules! partial_eq_fn {
+macro_rules! into_iterator_trait_ref_funcs {
+    () => {
+        type Item = (&'a K, &'a V);
+        type IntoIter = Iter<'a, K, V>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    };
+}
+
+macro_rules! len_trait_funcs {
+    () => {
+        #[inline]
+        fn len(&self) -> usize {
+            self.len()
+        }
+
+        #[inline]
+        fn is_empty(&self) -> bool {
+            self.is_empty()
+        }
+    };
+}
+
+macro_rules! map_extras_trait_funcs {
+    () => {
+        fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
+            self.get_key_value(key)
+        }
+
+        fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: Eq,
+        {
+            self.get_disjoint_mut(keys)
+        }
+
+        unsafe fn get_disjoint_unchecked_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
+            // SAFETY: The caller is responsible for ensuring that the keys are valid and unique
+            unsafe { self.get_disjoint_unchecked_mut(keys) }
+        }
+    };
+}
+
+macro_rules! map_iteration_trait_funcs {
+    () => {
+        type IntoKeyIterator = IntoKeys<K, V>;
+        type IntoValueIterator = IntoValues<K, V>;
+
+        fn iter(&self) -> Self::Iterator<'_> {
+            self.iter()
+        }
+
+        fn iter_mut(&mut self) -> Self::MutIterator<'_> {
+            self.iter_mut()
+        }
+
+        fn keys(&self) -> Self::KeyIterator<'_> {
+            self.keys()
+        }
+
+        fn into_keys(self) -> Self::IntoKeyIterator {
+            self.into_keys()
+        }
+
+        fn values(&self) -> Self::ValueIterator<'_> {
+            self.values()
+        }
+
+        fn values_mut(&mut self) -> Self::ValueMutIterator<'_> {
+            self.values_mut()
+        }
+
+        fn into_values(self) -> Self::IntoValueIterator {
+            self.into_values()
+        }
+    };
+}
+
+macro_rules! map_query_trait_funcs {
+    () => {
+        #[inline]
+        fn get(&self, key: &Q) -> Option<&V> {
+            self.get(key)
+        }
+
+        #[inline]
+        fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
+            self.get_mut(key)
+        }
+
+        #[inline]
+        fn contains_key(&self, key: &Q) -> bool {
+            self.contains_key(key)
+        }
+    };
+}
+
+macro_rules! partial_eq_trait_funcs {
     () => {
         fn eq(&self, other: &MT) -> bool {
             if self.len() != other.len() {
                 return false;
             }
 
-            return self
-                .iter()
-                .all(|(key, value)| other.get(key).map_or(false, |v| *value == *v));
+            self.iter().all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
         }
     };
 }
 
-macro_rules! debug_fn {
+macro_rules! scan_primary_funcs {
     () => {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-            let pairs = self.entries.iter().map(|x| (&x.0, &x.1));
-            f.debug_map().entries(pairs).finish()
+        #[doc = include_str!("../doc_snippets/get.md")]
+        #[inline]
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: ?Sized + Equivalent<K>,
+        {
+            let mut result = None;
+            for entry in &self.entries {
+                if key.equivalent(&entry.0) {
+                    result = Some(&entry.1);
+                }
+            }
+
+            result
+        }
+
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
+        #[inline]
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: ?Sized + Equivalent<K>,
+        {
+            let mut result = None;
+            for entry in &mut self.entries {
+                if key.equivalent(&entry.0) {
+                    result = Some(&mut entry.1);
+                }
+            }
+
+            result
+        }
+
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
+        #[inline]
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: ?Sized + Equivalent<K>,
+        {
+            let mut result = None;
+            for entry in &self.entries {
+                if key.equivalent(&entry.0) {
+                    result = Some((&entry.0, &entry.1));
+                }
+            }
+
+            result
+        }
+
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: ?Sized + Equivalent<K>,
+        {
+            self.get(key).is_some()
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_mut.md")]
+        pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Eq + Equivalent<K>,
+        {
+            get_disjoint_mut_funcs!(@safe_body, self, keys);
+        }
+
+        #[doc = include_str!("../doc_snippets/get_disjoint_unchecked_mut.md")]
+        pub unsafe fn get_disjoint_unchecked_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+        where
+            Q: ?Sized + Equivalent<K>,
+        {
+            get_disjoint_mut_funcs!(@unsafe_body, self, keys);
         }
     };
 }
 
 #[cfg(feature = "serde")]
-macro_rules! serialize_fn {
+macro_rules! serialize_trait_funcs {
     () => {
         fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
         where
@@ -165,292 +648,106 @@ macro_rules! serialize_fn {
     };
 }
 
-macro_rules! map_iteration_funcs {
-    ($($entries:ident)+) => {
-        type IntoKeyIterator = IntoKeys<K, V>;
-        type IntoValueIterator = IntoValues<K, V>;
-
-        fn iter(&self) -> Self::Iterator<'_> {
-            Iter::new(&self$(. $entries)+)
-        }
-
-        fn keys(&self) -> Self::KeyIterator<'_> {
-            Keys::new(&self$(. $entries)+)
-        }
-
-        fn values(&self) -> Self::ValueIterator<'_> {
-            Values::new(&self$(. $entries)+)
-        }
-
-        fn into_keys(self) -> Self::IntoKeyIterator {
-            // NOTE: this allocates and copies everything into a vector for the sake of iterating the vector.
-            // This is the best I could come up with, let me know if you see a way around the need to copy.
-            IntoKeys::new(Vec::from(self$(. $entries)+).into_boxed_slice())
-        }
-
-        fn into_values(self) -> Self::IntoValueIterator {
-            // NOTE: this allocates and copies everything into a vector for the sake of iterating the vector.
-            // This is the best I could come up with, let me know if you see a way around the need to copy.
-            IntoValues::new(Vec::from(self$(. $entries)+).into_boxed_slice())
-        }
-
-        fn iter_mut(&mut self) -> Self::MutIterator<'_> {
-            IterMut::new(self$(. $entries)+.as_mut())
-        }
-
-        fn values_mut(&mut self) -> Self::ValueMutIterator<'_> {
-            ValuesMut::new(self$(. $entries)+.as_mut())
-        }
-    };
-}
-
-macro_rules! dense_scalar_lookup_query_funcs {
+macro_rules! sparse_scalar_lookup_primary_funcs {
     () => {
+        #[doc = include_str!("../doc_snippets/get.md")]
         #[inline]
-        fn get(&self, key: &K) -> Option<&V> {
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            Q: Comparable<K> + Scalar,
+        {
             let index = key.index();
             if index >= self.min && index <= self.max {
-                let entry = unsafe { self.entries.get_unchecked(index - self.min) };
-                Some(&entry.1)
-            } else {
-                None
-            }
-        }
+                let index_in_lookup = index - self.min;
 
-        #[inline]
-        fn get_key_value(&self, key: &K) -> Option<(&K, &V)> {
-            let index = key.index();
-            if index >= self.min && index <= self.max {
-                let entry = unsafe { self.entries.get_unchecked(index - self.min) };
-                Some((&entry.0, &entry.1))
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-            let index = key.index();
-            if index >= self.min && index <= self.max {
-                let entry = unsafe { self.entries.get_unchecked_mut(index - self.min) };
-                Some(&mut entry.1)
-            } else {
-                None
-            }
-        }
-    };
-}
-
-macro_rules! binary_search_query_funcs {
-    () => {
-        #[inline]
-        fn get(&self, key: &Q) -> Option<&V> {
-            self.entries
-                .binary_search_by(|entry| key.compare(&entry.0).reverse())
-                .map(|index| {
-                    let entry = unsafe { self.entries.get_unchecked(index) };
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let index_in_entries: usize = unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
+                (index_in_entries > 0).then(|| {
+                    // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                    let entry = unsafe { self.entries.get_unchecked(index_in_entries - 1) };
                     &entry.1
                 })
-                .ok()
+            } else {
+                None
+            }
         }
 
+        #[doc = include_str!("../doc_snippets/get_mut.md")]
         #[inline]
-        fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-            self.entries
-                .binary_search_by(|entry| key.compare(&entry.0).reverse())
-                .map(|index| {
-                    let entry = unsafe { self.entries.get_unchecked_mut(index) };
+        fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            let index = key.index();
+            if index >= self.min && index <= self.max {
+                let index_in_lookup = index - self.min;
+
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let index_in_entries: usize = unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
+                (index_in_entries > 0).then(|| {
+                    // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                    let entry = unsafe { self.entries.get_unchecked_mut(index_in_entries - 1) };
                     &mut entry.1
                 })
-                .ok()
+            } else {
+                None
+            }
         }
 
+        #[doc = include_str!("../doc_snippets/get_key_value.md")]
         #[inline]
-        fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-            self.entries
-                .binary_search_by(|entry| key.compare(&entry.0).reverse())
-                .map(|index| {
-                    let entry = unsafe { self.entries.get_unchecked(index) };
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            let index = key.index();
+            if index >= self.min && index <= self.max {
+                let index_in_lookup = index - self.min;
+
+                // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                let index_in_entries: usize = unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
+                (index_in_entries > 0).then(|| {
+                    // SAFETY: We are guaranteed that the index is valid because we checked it against min and max
+                    let entry = unsafe { self.entries.get_unchecked(index_in_entries - 1) };
                     (&entry.0, &entry.1)
                 })
-                .ok()
-        }
-    };
-}
-
-macro_rules! eytzinger_search_query_funcs {
-    () => {
-        #[inline]
-        fn get(&self, key: &Q) -> Option<&V> {
-            if let Some(index) =
-                eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse())
-            {
-                let entry = unsafe { self.entries.get_unchecked(index) };
-                Some(&entry.1)
             } else {
                 None
             }
         }
 
+        #[doc = include_str!("../doc_snippets/contains_key.md")]
         #[inline]
-        fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-            if let Some(index) =
-                eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse())
-            {
-                let entry = unsafe { self.entries.get_unchecked_mut(index) };
-                Some(&mut entry.1)
-            } else {
-                None
-            }
+        #[must_use]
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            Q: Comparable<K> + Scalar,
+        {
+            self.get(key).is_some()
         }
 
-        #[inline]
-        fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-            if let Some(index) =
-                eytzinger_search_by(&self.entries, |entry| key.compare(&entry.0).reverse())
-            {
-                let entry = unsafe { self.entries.get_unchecked(index) };
-                Some((&entry.0, &entry.1))
-            } else {
-                None
-            }
-        }
+        get_disjoint_mut_funcs!("Scalar");
     };
 }
 
-macro_rules! sparse_scalar_lookup_query_funcs {
-    () => {
-        #[inline]
-        fn get(&self, key: &K) -> Option<&V> {
-            let index = key.index();
-            if index >= self.min && index <= self.max {
-                let index_in_lookup = index - self.min;
-                let index_in_entries: usize =
-                    unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
-                if index_in_entries > 0 {
-                    let entry = unsafe { self.entries.get_unchecked(index_in_entries - 1) };
-                    return Some(&entry.1);
-                }
-            }
-
-            None
-        }
-
-        #[inline]
-        fn get_key_value(&self, key: &K) -> Option<(&K, &V)> {
-            let index = key.index();
-            if index >= self.min && index <= self.max {
-                let index_in_lookup = index - self.min;
-                let index_in_entries: usize =
-                    unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
-                if index_in_entries > 0 {
-                    let entry = unsafe { self.entries.get_unchecked(index_in_entries - 1) };
-                    return Some((&entry.0, &entry.1));
-                }
-            }
-
-            None
-        }
-
-        #[inline]
-        fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-            let index = key.index();
-            if index >= self.min && index <= self.max {
-                let index_in_lookup = index - self.min;
-                let index_in_entries: usize =
-                    unsafe { (*self.lookup.get_unchecked(index_in_lookup)).into() };
-                if index_in_entries > 0 {
-                    let entry = unsafe { self.entries.get_unchecked_mut(index_in_entries - 1) };
-                    return Some(&mut entry.1);
-                }
-            }
-
-            None
-        }
-    };
-}
-
-macro_rules! scan_query_funcs {
-    () => {
-        #[inline]
-        fn get(&self, key: &Q) -> Option<&V> {
-            let mut result = None;
-            for entry in &self.entries {
-                if key.equivalent(&entry.0) {
-                    result = Some(&entry.1);
-                }
-            }
-
-            result
-        }
-
-        #[inline]
-        fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-            let mut result = None;
-            for entry in &mut self.entries {
-                if key.equivalent(&entry.0) {
-                    result = Some(&mut entry.1);
-                }
-            }
-
-            result
-        }
-
-        #[inline]
-        fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-            let mut result = None;
-            for entry in &self.entries {
-                if key.equivalent(&entry.0) {
-                    result = Some((&entry.0, &entry.1));
-                }
-            }
-
-            result
-        }
-    };
-}
-
-macro_rules! hash_query_funcs {
-    () => {
-        #[inline]
-        fn get(&self, key: &Q) -> Option<&V> {
-            self.table
-                .find(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
-                .map(|(_, v)| v)
-        }
-
-        #[inline]
-        fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-            self.table
-                .find(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
-                .map(|(k, v)| (k, v))
-        }
-
-        #[inline]
-        fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-            self.table
-                .find_mut(self.hasher.hash(key), |entry| key.equivalent(&entry.0))
-                .map(|(_, v)| v)
-        }
-    };
-}
-
-pub(crate) use binary_search_query_funcs;
-pub(crate) use debug_fn;
-pub(crate) use dense_scalar_lookup_query_funcs;
-pub(crate) use eytzinger_search_query_funcs;
-pub(crate) use get_disjoint_mut_fn;
-pub(crate) use get_disjoint_unchecked_mut_body;
-pub(crate) use get_disjoint_unchecked_mut_fn;
-pub(crate) use hash_query_funcs;
-pub(crate) use index_fn;
-pub(crate) use into_iter_fn;
-pub(crate) use into_iter_mut_ref_fn;
-pub(crate) use into_iter_ref_fn;
-pub(crate) use map_iteration_funcs;
-pub(crate) use partial_eq_fn;
-pub(crate) use scan_query_funcs;
-pub(crate) use sparse_scalar_lookup_query_funcs;
+pub(crate) use binary_search_primary_funcs;
+pub(crate) use common_primary_funcs;
+pub(crate) use debug_trait_funcs;
+pub(crate) use dense_scalar_lookup_primary_funcs;
+pub(crate) use eytzinger_search_primary_funcs;
+pub(crate) use get_disjoint_mut_funcs;
+pub(crate) use hash_primary_funcs;
+pub(crate) use index_trait_funcs;
+pub(crate) use into_iterator_trait_funcs;
+pub(crate) use into_iterator_trait_mut_ref_funcs;
+pub(crate) use into_iterator_trait_ref_funcs;
+pub(crate) use len_trait_funcs;
+pub(crate) use map_extras_trait_funcs;
+pub(crate) use map_iteration_trait_funcs;
+pub(crate) use map_query_trait_funcs;
+pub(crate) use partial_eq_trait_funcs;
+pub(crate) use scan_primary_funcs;
+pub(crate) use sparse_scalar_lookup_primary_funcs;
 
 #[cfg(feature = "serde")]
-pub(crate) use serialize_fn;
+pub(crate) use serialize_trait_funcs;

--- a/frozen-collections-core/src/maps/dense_scalar_lookup_map.rs
+++ b/frozen-collections-core/src/maps/dense_scalar_lookup_map.rs
@@ -1,20 +1,21 @@
 use crate::maps::decl_macros::{
-    debug_fn, dense_scalar_lookup_query_funcs, get_disjoint_mut_fn,
-    get_disjoint_unchecked_mut_body, get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn,
-    into_iter_mut_ref_fn, into_iter_ref_fn, map_iteration_funcs, partial_eq_fn,
+    common_primary_funcs, debug_trait_funcs, dense_scalar_lookup_primary_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery, Scalar};
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery, Scalar};
 use crate::utils::dedup_by_keep_last;
-use alloc::boxed::Box;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
+use equivalent::Comparable;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::string::String, alloc::string::ToString, alloc::vec::Vec};
 
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -31,17 +32,17 @@ pub struct DenseScalarLookupMap<K, V> {
     entries: Box<[(K, V)]>,
 }
 
-impl<K, V> DenseScalarLookupMap<K, V>
-where
-    K: Scalar,
-{
+impl<K, V> DenseScalarLookupMap<K, V> {
     /// Creates a frozen map.
     ///
     /// # Errors
     ///
     /// Fails if all the keys in the input vector, after sorting and dedupping,
     /// don't represent a continuous range of values.
-    pub fn new(mut entries: Vec<(K, V)>) -> core::result::Result<Self, String> {
+    pub fn new(mut entries: Vec<(K, V)>) -> core::result::Result<Self, String>
+    where
+        K: Scalar,
+    {
         entries.sort_by_key(|x| x.0);
         dedup_by_keep_last(&mut entries, |x, y| x.0.eq(&y.0));
 
@@ -64,13 +65,19 @@ where
     /// This function assumes that `min` <= `max` and that the vector is sorted according to the
     /// order of the [`Ord`] trait.
     #[must_use]
-    pub(crate) fn new_raw(processed_entries: Vec<(K, V)>) -> Self {
+    pub(crate) fn new_raw(processed_entries: Vec<(K, V)>) -> Self
+    where
+        K: Scalar,
+    {
         Self {
             min: processed_entries[0].0.index(),
             max: processed_entries[processed_entries.len() - 1].0.index(),
             entries: processed_entries.into_boxed_slice(),
         }
     }
+
+    dense_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(non_const_len, entries);
 }
 
 impl<K, V> Default for DenseScalarLookupMap<K, V> {
@@ -83,19 +90,20 @@ impl<K, V> Default for DenseScalarLookupMap<K, V> {
     }
 }
 
-impl<K, V> Map<K, V, K> for DenseScalarLookupMap<K, V>
+impl<K, V, Q> Map<K, V, Q> for DenseScalarLookupMap<K, V> where Q: Scalar + Comparable<K> {}
+
+impl<K, V, Q> MapExtras<K, V, Q> for DenseScalarLookupMap<K, V>
 where
-    K: Scalar,
+    Q: Scalar + Comparable<K>,
 {
-    get_disjoint_mut_fn!("Scalar");
-    get_disjoint_unchecked_mut_fn!("Scalar");
+    map_extras_trait_funcs!();
 }
 
-impl<K, V> MapQuery<K, V, K> for DenseScalarLookupMap<K, V>
+impl<K, V, Q> MapQuery<Q, V> for DenseScalarLookupMap<K, V>
 where
-    K: Scalar,
+    Q: Scalar + Comparable<K>,
 {
-    dense_scalar_lookup_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V> MapIteration<K, V> for DenseScalarLookupMap<K, V> {
@@ -129,41 +137,39 @@ impl<K, V> MapIteration<K, V> for DenseScalarLookupMap<K, V> {
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V> Len for DenseScalarLookupMap<K, V> {
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, V> Index<&Q> for DenseScalarLookupMap<Q, V>
 where
     Q: Scalar,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V> IntoIterator for DenseScalarLookupMap<K, V> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a DenseScalarLookupMap<K, V> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a mut DenseScalarLookupMap<K, V> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT> PartialEq<MT> for DenseScalarLookupMap<K, V>
 where
     K: Scalar,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V> Eq for DenseScalarLookupMap<K, V>
@@ -175,19 +181,19 @@ where
 
 impl<K, V> Debug for DenseScalarLookupMap<K, V>
 where
-    K: Debug,
+    K: Scalar + Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
 impl<K, V> Serialize for DenseScalarLookupMap<K, V>
 where
-    K: Serialize,
+    K: Serialize + Scalar,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }
 
 #[cfg(test)]
@@ -198,9 +204,6 @@ mod tests {
     #[test]
     fn error_in_new() {
         let map = DenseScalarLookupMap::<u8, u8>::new(vec![(1, 1), (2, 2), (4, 3)]);
-        assert_eq!(
-            map,
-            Err("keys must be in a contiguous range <= usize::MAX in size".to_string())
-        );
+        assert_eq!(map, Err("keys must be in a contiguous range <= usize::MAX in size".to_string()));
     }
 }

--- a/frozen-collections-core/src/maps/eytzinger_search_map.rs
+++ b/frozen-collections-core/src/maps/eytzinger_search_map.rs
@@ -1,21 +1,21 @@
 use crate::maps::decl_macros::{
-    debug_fn, eytzinger_search_query_funcs, get_disjoint_mut_fn, get_disjoint_unchecked_mut_body,
-    get_disjoint_unchecked_mut_fn, index_fn, into_iter_fn, into_iter_mut_ref_fn, into_iter_ref_fn,
-    map_iteration_funcs, partial_eq_fn,
+    common_primary_funcs, debug_trait_funcs, eytzinger_search_primary_funcs, get_disjoint_mut_funcs, index_trait_funcs,
+    into_iterator_trait_funcs, into_iterator_trait_mut_ref_funcs, into_iterator_trait_ref_funcs, len_trait_funcs, map_extras_trait_funcs,
+    map_iteration_trait_funcs, map_query_trait_funcs, partial_eq_trait_funcs,
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::traits::{Len, Map, MapIteration, MapQuery};
+use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
 use crate::utils::{dedup_by_keep_last, eytzinger_search_by, eytzinger_sort};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
-use core::option::Option;
 use equivalent::Comparable;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::vec::Vec};
 
 #[cfg(feature = "serde")]
 use {
-    crate::maps::decl_macros::serialize_fn,
+    crate::maps::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeMap,
     serde::{Serialize, Serializer},
 };
@@ -31,13 +31,13 @@ pub struct EytzingerSearchMap<K, V> {
     entries: Box<[(K, V)]>,
 }
 
-impl<K, V> EytzingerSearchMap<K, V>
-where
-    K: Ord,
-{
+impl<K, V> EytzingerSearchMap<K, V> {
     /// Creates a frozen map.
     #[must_use]
-    pub fn new(mut entries: Vec<(K, V)>) -> Self {
+    pub fn new(mut entries: Vec<(K, V)>) -> Self
+    where
+        K: Ord,
+    {
         entries.sort_by(|x, y| x.0.cmp(&y.0));
         dedup_by_keep_last(&mut entries, |x, y| x.0.eq(&y.0));
         eytzinger_sort(&mut entries);
@@ -51,29 +51,31 @@ where
             entries: processed_entries.into_boxed_slice(),
         }
     }
+
+    eytzinger_search_primary_funcs!();
+    common_primary_funcs!(non_const_len, entries);
 }
 
 impl<K, V> Default for EytzingerSearchMap<K, V> {
     fn default() -> Self {
-        Self {
-            entries: Box::default(),
-        }
+        Self { entries: Box::default() }
     }
 }
 
-impl<K, V, Q> Map<K, V, Q> for EytzingerSearchMap<K, V>
+impl<K, V, Q> Map<K, V, Q> for EytzingerSearchMap<K, V> where Q: ?Sized + Comparable<K> {}
+
+impl<K, V, Q> MapExtras<K, V, Q> for EytzingerSearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    get_disjoint_mut_fn!();
-    get_disjoint_unchecked_mut_fn!();
+    map_extras_trait_funcs!();
 }
 
-impl<K, V, Q> MapQuery<K, V, Q> for EytzingerSearchMap<K, V>
+impl<K, V, Q> MapQuery<Q, V> for EytzingerSearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    eytzinger_search_query_funcs!();
+    map_query_trait_funcs!();
 }
 
 impl<K, V> MapIteration<K, V> for EytzingerSearchMap<K, V> {
@@ -107,41 +109,39 @@ impl<K, V> MapIteration<K, V> for EytzingerSearchMap<K, V> {
         K: 'a,
         V: 'a;
 
-    map_iteration_funcs!(entries);
+    map_iteration_trait_funcs!();
 }
 
 impl<K, V> Len for EytzingerSearchMap<K, V> {
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<Q, K, V> Index<&Q> for EytzingerSearchMap<K, V>
 where
-    Q: ?Sized + Eq + Comparable<K>,
+    Q: ?Sized + Comparable<K>,
 {
-    index_fn!();
+    index_trait_funcs!();
 }
 
 impl<K, V> IntoIterator for EytzingerSearchMap<K, V> {
-    into_iter_fn!(entries);
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a EytzingerSearchMap<K, V> {
-    into_iter_ref_fn!();
+    into_iterator_trait_ref_funcs!();
 }
 
 impl<'a, K, V> IntoIterator for &'a mut EytzingerSearchMap<K, V> {
-    into_iter_mut_ref_fn!();
+    into_iterator_trait_mut_ref_funcs!();
 }
 
 impl<K, V, MT> PartialEq<MT> for EytzingerSearchMap<K, V>
 where
     K: Ord,
     V: PartialEq,
-    MT: Map<K, V>,
+    MT: MapQuery<K, V>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<K, V> Eq for EytzingerSearchMap<K, V>
@@ -156,7 +156,7 @@ where
     K: Debug,
     V: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -165,5 +165,5 @@ where
     K: Serialize,
     V: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/maps/iterators.rs
+++ b/frozen-collections-core/src/maps/iterators.rs
@@ -1,6 +1,8 @@
-use alloc::boxed::Box;
 use core::fmt::{Debug, Formatter};
 use core::iter::FusedIterator;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
 
 /// An iterator over the entries of a map.
 pub struct Iter<'a, K, V> {
@@ -9,9 +11,7 @@ pub struct Iter<'a, K, V> {
 
 impl<'a, K, V> Iter<'a, K, V> {
     pub(crate) fn new(entries: &'a [(K, V)]) -> Self {
-        Self {
-            inner: entries.iter(),
-        }
+        Self { inner: entries.iter() }
     }
 }
 
@@ -50,9 +50,7 @@ impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
 
 impl<K, V> Clone for Iter<'_, K, V> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
+        Self { inner: self.inner.clone() }
     }
 }
 
@@ -73,9 +71,7 @@ pub struct IterMut<'a, K, V> {
 
 impl<'a, K, V> IterMut<'a, K, V> {
     pub(crate) fn new(entries: &'a mut [(K, V)]) -> Self {
-        Self {
-            inner: entries.iter_mut(),
-        }
+        Self { inner: entries.iter_mut() }
     }
 }
 
@@ -131,10 +127,8 @@ pub struct Keys<'a, K, V> {
 
 impl<'a, K, V> Keys<'a, K, V> {
     #[must_use]
-    pub fn new(entries: &'a [(K, V)]) -> Self {
-        Self {
-            inner: Iter::new(entries),
-        }
+    pub(crate) fn new(entries: &'a [(K, V)]) -> Self {
+        Self { inner: Iter::new(entries) }
     }
 }
 
@@ -172,9 +166,7 @@ impl<K, V> FusedIterator for Keys<'_, K, V> {}
 
 impl<K, V> Clone for Keys<'_, K, V> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
+        Self { inner: self.inner.clone() }
     }
 }
 
@@ -194,10 +186,8 @@ pub struct Values<'a, K, V> {
 
 impl<'a, K, V> Values<'a, K, V> {
     #[must_use]
-    pub fn new(entries: &'a [(K, V)]) -> Self {
-        Self {
-            inner: Iter::new(entries),
-        }
+    pub(crate) fn new(entries: &'a [(K, V)]) -> Self {
+        Self { inner: Iter::new(entries) }
     }
 }
 
@@ -235,9 +225,7 @@ impl<K, V> FusedIterator for Values<'_, K, V> {}
 
 impl<K, V> Clone for Values<'_, K, V> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
+        Self { inner: self.inner.clone() }
     }
 }
 
@@ -461,7 +449,6 @@ impl<K, V> FusedIterator for IntoValues<K, V> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
     use alloc::{format, vec};
 
     #[test]
@@ -471,10 +458,7 @@ mod tests {
         assert_eq!(entries.len(), iter.len());
 
         let collected: Vec<_> = iter.collect();
-        assert_eq!(
-            collected,
-            vec![(&"Alice", &1), (&"Bob", &2), (&"Sandy", &3), (&"Tom", &4)]
-        );
+        assert_eq!(collected, vec![(&"Alice", &1), (&"Bob", &2), (&"Sandy", &3), (&"Tom", &4)]);
     }
 
     #[test]
@@ -791,10 +775,7 @@ mod tests {
         assert_eq!(4, into_iter.len());
 
         let collected: Vec<_> = into_iter.collect();
-        assert_eq!(
-            collected,
-            vec![("Alice", 1), ("Bob", 2), ("Sandy", 3), ("Tom", 4)]
-        );
+        assert_eq!(collected, vec![("Alice", 1), ("Bob", 2), ("Sandy", 3), ("Tom", 4)]);
     }
 
     #[test]

--- a/frozen-collections-core/src/sets/binary_search_set.rs
+++ b/frozen-collections-core/src/sets/binary_search_set.rs
@@ -1,18 +1,20 @@
+use crate::maps::BinarySearchMap;
+use crate::maps::decl_macros::len_trait_funcs;
+use crate::sets::decl_macros::{
+    binary_search_primary_funcs, bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
+};
+use crate::sets::{IntoIter, Iter};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
-
-use crate::maps::BinarySearchMap;
-use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
-};
-use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -28,15 +30,15 @@ pub struct BinarySearchSet<T> {
     map: BinarySearchMap<T, ()>,
 }
 
-impl<T> BinarySearchSet<T>
-where
-    T: Ord,
-{
+impl<T> BinarySearchSet<T> {
     /// Creates a frozen set.
     #[must_use]
     pub const fn new(map: BinarySearchMap<T, ()>) -> Self {
         Self { map }
     }
+
+    binary_search_primary_funcs!();
+    common_primary_funcs!(non_const_len);
 }
 
 impl<T> Default for BinarySearchSet<T> {
@@ -47,13 +49,20 @@ impl<T> Default for BinarySearchSet<T> {
     }
 }
 
-impl<T> Set<T, T> for BinarySearchSet<T> where T: Ord {}
+impl<T, Q> Set<T, Q> for BinarySearchSet<T> where Q: ?Sized + Comparable<T> {}
 
-impl<T> SetQuery<T, T> for BinarySearchSet<T>
+impl<T, Q> SetExtras<T, Q> for BinarySearchSet<T>
 where
-    T: Ord,
+    Q: ?Sized + Comparable<T>,
 {
-    get_fn!("Scalar");
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q> SetQuery<Q> for BinarySearchSet<T>
+where
+    Q: ?Sized + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T> SetIteration<T> for BinarySearchSet<T> {
@@ -62,13 +71,11 @@ impl<T> SetIteration<T> for BinarySearchSet<T> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T> Len for BinarySearchSet<T> {
-    fn len(&self) -> usize {
-        self.map.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST> BitOr<&ST> for &BinarySearchSet<T>
@@ -76,7 +83,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST> BitAnd<&ST> for &BinarySearchSet<T>
@@ -84,7 +91,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST> BitXor<&ST> for &BinarySearchSet<T>
@@ -92,7 +99,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST> Sub<&ST> for &BinarySearchSet<T>
@@ -100,23 +107,23 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T> IntoIterator for BinarySearchSet<T> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T> IntoIterator for &'a BinarySearchSet<T> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST> PartialEq<ST> for BinarySearchSet<T>
 where
     T: Ord,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T> Eq for BinarySearchSet<T> where T: Ord {}
@@ -125,7 +132,7 @@ impl<T> Debug for BinarySearchSet<T>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -133,5 +140,5 @@ impl<T> Serialize for BinarySearchSet<T>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/sets/decl_macros.rs
+++ b/frozen-collections-core/src/sets/decl_macros.rs
@@ -1,20 +1,209 @@
-macro_rules! get_fn {
-    ("Scalar") => {
+macro_rules! binary_search_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
         #[inline]
-        fn get(&self, value: &T) -> Option<&T> {
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Comparable<T>,
+        {
             Some(self.map.get_key_value(value)?.0)
         }
-    };
 
-    () => {
+        #[doc = include_str!("../doc_snippets/contains.md")]
         #[inline]
-        fn get(&self, value: &Q) -> Option<&T> {
-            Some(self.map.get_key_value(value)?.0)
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<T>,
+        {
+            self.get(value).is_some()
         }
     };
 }
 
-macro_rules! partial_eq_fn {
+macro_rules! bitand_trait_funcs {
+    () => {
+        type Output = hashbrown::HashSet<T>;
+
+        fn bitand(self, rhs: &ST) -> Self::Output {
+            Self::Output::from_iter(self.intersection(rhs).cloned())
+        }
+    };
+}
+
+macro_rules! bitor_trait_funcs {
+    () => {
+        type Output = hashbrown::HashSet<T>;
+
+        fn bitor(self, rhs: &ST) -> Self::Output {
+            Self::Output::from_iter(self.union(rhs).cloned())
+        }
+    };
+}
+
+macro_rules! bitxor_trait_funcs {
+    () => {
+        type Output = hashbrown::HashSet<T>;
+
+        fn bitxor(self, rhs: &ST) -> Self::Output {
+            self.symmetric_difference(rhs).cloned().collect()
+        }
+    };
+}
+
+macro_rules! common_primary_funcs {
+    ($const_len:ident) => {
+        #[doc = include_str!("../doc_snippets/iter.md")]
+        #[must_use]
+        pub fn iter(&self) -> Iter<'_, T> {
+            Iter::new(self.map.iter())
+        }
+
+        #[must_use]
+        fn into_iter(self) -> IntoIter<T> {
+            IntoIter::new(self.map.into_iter())
+        }
+
+        common_primary_funcs!(@len $const_len);
+    };
+
+    (@len const_len) => {
+        #[doc = include_str!("../doc_snippets/len.md")]
+        #[inline]
+        #[must_use]
+        pub const fn len(&self) -> usize {
+            self.map.len()
+        }
+
+        #[doc = include_str!("../doc_snippets/is_empty.md")]
+        #[inline]
+        #[must_use]
+        pub const fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+    };
+
+    (@len non_const_len) => {
+        #[doc = include_str!("../doc_snippets/len.md")]
+        #[must_use]
+        pub fn len(&self) -> usize {
+            self.map.len()
+        }
+
+        #[doc = include_str!("../doc_snippets/is_empty.md")]
+        #[must_use]
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+    };
+}
+
+macro_rules! debug_trait_funcs {
+    () => {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_set().entries(self.iter()).finish()
+        }
+    };
+}
+
+macro_rules! dense_scalar_lookup_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
+        #[inline]
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Comparable<T> + Scalar,
+        {
+            Some(self.map.get_key_value(value)?.0)
+        }
+
+        #[doc = include_str!("../doc_snippets/contains.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<T> + Scalar,
+        {
+            self.get(value).is_some()
+        }
+    };
+}
+
+macro_rules! eytzinger_search_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
+        #[inline]
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Comparable<T>,
+        {
+            Some(self.map.get_key_value(value)?.0)
+        }
+
+        #[doc = include_str!("../doc_snippets/contains.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<T>,
+        {
+            self.get(value).is_some()
+        }
+    };
+}
+
+macro_rules! hash_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
+        #[inline]
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Equivalent<T>,
+            H: Hasher<Q>,
+        {
+            Some(self.map.get_key_value(value)?.0)
+        }
+
+        #[doc = include_str!("../doc_snippets/contains.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Equivalent<T>,
+            H: Hasher<Q>,
+        {
+            self.get(value).is_some()
+        }
+    };
+}
+
+macro_rules! into_iterator_trait_funcs {
+    () => {
+        type Item = T;
+        type IntoIter = IntoIter<T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.into_iter()
+        }
+    };
+}
+
+macro_rules! into_iterator_ref_trait_funcs {
+    () => {
+        type Item = &'a T;
+        type IntoIter = Iter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    };
+}
+
+macro_rules! partial_eq_trait_funcs {
     () => {
         fn eq(&self, other: &ST) -> bool {
             if self.len() != other.len() {
@@ -26,78 +215,32 @@ macro_rules! partial_eq_fn {
     };
 }
 
-macro_rules! into_iter_fn {
+macro_rules! scan_primary_funcs {
     () => {
-        type Item = T;
-        type IntoIter = IntoIter<T>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            IntoIter::new(self.map.into_iter())
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
+        #[inline]
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Equivalent<T>,
+        {
+            Some(self.map.get_key_value(value)?.0)
         }
-    };
-}
 
-macro_rules! into_iter_ref_fn {
-    () => {
-        type Item = &'a T;
-        type IntoIter = Iter<'a, T>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            self.iter()
-        }
-    };
-}
-
-macro_rules! bitor_fn {
-    () => {
-        type Output = hashbrown::HashSet<T>;
-
-        fn bitor(self, rhs: &ST) -> Self::Output {
-            Self::Output::from_iter(self.union(rhs).cloned())
-        }
-    };
-}
-
-macro_rules! bitand_fn {
-    () => {
-        type Output = hashbrown::HashSet<T>;
-
-        fn bitand(self, rhs: &ST) -> Self::Output {
-            Self::Output::from_iter(self.intersection(rhs).cloned())
-        }
-    };
-}
-
-macro_rules! bitxor_fn {
-    () => {
-        type Output = hashbrown::HashSet<T>;
-
-        fn bitxor(self, rhs: &ST) -> Self::Output {
-            self.symmetric_difference(rhs).cloned().collect()
-        }
-    };
-}
-
-macro_rules! sub_fn {
-    () => {
-        type Output = hashbrown::HashSet<T>;
-
-        fn sub(self, rhs: &ST) -> Self::Output {
-            self.difference(rhs).cloned().collect()
-        }
-    };
-}
-
-macro_rules! debug_fn {
-    () => {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_set().entries(self.iter()).finish()
+        #[doc = include_str!("../doc_snippets/contains.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Equivalent<T>,
+        {
+            self.get(value).is_some()
         }
     };
 }
 
 #[cfg(feature = "serde")]
-macro_rules! serialize_fn {
+macro_rules! serialize_trait_funcs {
     () => {
         fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
         where
@@ -112,24 +255,84 @@ macro_rules! serialize_fn {
     };
 }
 
-macro_rules! set_iteration_funcs {
+macro_rules! set_extras_trait_funcs {
     () => {
-        fn iter(&self) -> Iter<'_, T> {
-            Iter::new(self.map.iter())
+        #[inline]
+        fn get(&self, value: &Q) -> Option<&T> {
+            self.get(value)
         }
     };
 }
 
-pub(crate) use bitand_fn;
-pub(crate) use bitor_fn;
-pub(crate) use bitxor_fn;
-pub(crate) use debug_fn;
-pub(crate) use get_fn;
-pub(crate) use into_iter_fn;
-pub(crate) use into_iter_ref_fn;
-pub(crate) use partial_eq_fn;
-pub(crate) use set_iteration_funcs;
-pub(crate) use sub_fn;
+macro_rules! set_iteration_trait_funcs {
+    () => {
+        fn iter(&self) -> Self::Iterator<'_> {
+            self.iter()
+        }
+    };
+}
+
+macro_rules! set_query_trait_funcs {
+    () => {
+        #[inline]
+        fn contains(&self, value: &Q) -> bool {
+            self.contains(value)
+        }
+    };
+}
+
+macro_rules! sparse_scalar_lookup_primary_funcs {
+    () => {
+        #[doc = include_str!("../doc_snippets/get_from_set.md")]
+        #[inline]
+        #[must_use]
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            Q: ?Sized + Comparable<T> + Scalar,
+        {
+            Some(self.map.get_key_value(value)?.0)
+        }
+
+        #[doc = include_str!("../doc_snippets/contains.md")]
+        #[inline]
+        #[must_use]
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            Q: ?Sized + Comparable<T> + Scalar,
+        {
+            self.get(value).is_some()
+        }
+    };
+}
+
+macro_rules! sub_trait_funcs {
+    () => {
+        type Output = hashbrown::HashSet<T>;
+
+        fn sub(self, rhs: &ST) -> Self::Output {
+            self.difference(rhs).cloned().collect()
+        }
+    };
+}
+
+pub(crate) use binary_search_primary_funcs;
+pub(crate) use bitand_trait_funcs;
+pub(crate) use bitor_trait_funcs;
+pub(crate) use bitxor_trait_funcs;
+pub(crate) use common_primary_funcs;
+pub(crate) use debug_trait_funcs;
+pub(crate) use dense_scalar_lookup_primary_funcs;
+pub(crate) use eytzinger_search_primary_funcs;
+pub(crate) use hash_primary_funcs;
+pub(crate) use into_iterator_ref_trait_funcs;
+pub(crate) use into_iterator_trait_funcs;
+pub(crate) use partial_eq_trait_funcs;
+pub(crate) use scan_primary_funcs;
+pub(crate) use set_extras_trait_funcs;
+pub(crate) use set_iteration_trait_funcs;
+pub(crate) use set_query_trait_funcs;
+pub(crate) use sparse_scalar_lookup_primary_funcs;
+pub(crate) use sub_trait_funcs;
 
 #[cfg(feature = "serde")]
-pub(crate) use serialize_fn;
+pub(crate) use serialize_trait_funcs;

--- a/frozen-collections-core/src/sets/dense_scalar_lookup_set.rs
+++ b/frozen-collections-core/src/sets/dense_scalar_lookup_set.rs
@@ -1,17 +1,20 @@
 use crate::maps::DenseScalarLookupMap;
+use crate::maps::decl_macros::len_trait_funcs;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, dense_scalar_lookup_primary_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Scalar, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Scalar, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
+use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -26,10 +29,7 @@ pub struct DenseScalarLookupSet<T> {
     map: DenseScalarLookupMap<T, ()>,
 }
 
-impl<T> DenseScalarLookupSet<T>
-where
-    T: Scalar,
-{
+impl<T> DenseScalarLookupSet<T> {
     /// Creates a frozen set.
     ///
     /// # Errors
@@ -40,12 +40,12 @@ where
     pub const fn new(map: DenseScalarLookupMap<T, ()>) -> Self {
         Self { map }
     }
+
+    dense_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(non_const_len);
 }
 
-impl<T> Default for DenseScalarLookupSet<T>
-where
-    T: Scalar,
-{
+impl<T> Default for DenseScalarLookupSet<T> {
     fn default() -> Self {
         Self {
             map: DenseScalarLookupMap::default(),
@@ -53,13 +53,20 @@ where
     }
 }
 
-impl<T> Set<T, T> for DenseScalarLookupSet<T> where T: Scalar {}
+impl<T, Q> Set<T, Q> for DenseScalarLookupSet<T> where Q: Comparable<T> + Scalar {}
 
-impl<T> SetQuery<T, T> for DenseScalarLookupSet<T>
+impl<T, Q> SetExtras<T, Q> for DenseScalarLookupSet<T>
 where
-    T: Scalar,
+    Q: Scalar + Comparable<T>,
 {
-    get_fn!("Scalar");
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q> SetQuery<Q> for DenseScalarLookupSet<T>
+where
+    Q: Scalar + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T> SetIteration<T> for DenseScalarLookupSet<T> {
@@ -68,13 +75,11 @@ impl<T> SetIteration<T> for DenseScalarLookupSet<T> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T> Len for DenseScalarLookupSet<T> {
-    fn len(&self) -> usize {
-        self.map.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST> BitOr<&ST> for &DenseScalarLookupSet<T>
@@ -82,7 +87,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST> BitAnd<&ST> for &DenseScalarLookupSet<T>
@@ -90,7 +95,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST> BitXor<&ST> for &DenseScalarLookupSet<T>
@@ -98,7 +103,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST> Sub<&ST> for &DenseScalarLookupSet<T>
@@ -106,23 +111,23 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T> IntoIterator for DenseScalarLookupSet<T> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T> IntoIterator for &'a DenseScalarLookupSet<T> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST> PartialEq<ST> for DenseScalarLookupSet<T>
 where
     T: Scalar,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T> Eq for DenseScalarLookupSet<T> where T: Scalar {}
@@ -131,7 +136,7 @@ impl<T> Debug for DenseScalarLookupSet<T>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -139,5 +144,5 @@ impl<T> Serialize for DenseScalarLookupSet<T>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/sets/eytzinger_search_set.rs
+++ b/frozen-collections-core/src/sets/eytzinger_search_set.rs
@@ -1,10 +1,12 @@
 use crate::maps::EytzingerSearchMap;
+use crate::maps::decl_macros::len_trait_funcs;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, eytzinger_search_primary_funcs,
+    into_iterator_ref_trait_funcs, into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
@@ -12,7 +14,7 @@ use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -28,15 +30,15 @@ pub struct EytzingerSearchSet<T> {
     map: EytzingerSearchMap<T, ()>,
 }
 
-impl<T> EytzingerSearchSet<T>
-where
-    T: Ord,
-{
+impl<T> EytzingerSearchSet<T> {
     /// Creates a frozen set.
     #[must_use]
     pub const fn new(map: EytzingerSearchMap<T, ()>) -> Self {
         Self { map }
     }
+
+    eytzinger_search_primary_funcs!();
+    common_primary_funcs!(non_const_len);
 }
 
 impl<T> Default for EytzingerSearchSet<T> {
@@ -49,11 +51,18 @@ impl<T> Default for EytzingerSearchSet<T> {
 
 impl<T, Q> Set<T, Q> for EytzingerSearchSet<T> where Q: ?Sized + Eq + Comparable<T> {}
 
-impl<T, Q> SetQuery<T, Q> for EytzingerSearchSet<T>
+impl<T, Q> SetExtras<T, Q> for EytzingerSearchSet<T>
 where
-    Q: ?Sized + Eq + Comparable<T>,
+    Q: ?Sized + Comparable<T>,
 {
-    get_fn!();
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q> SetQuery<Q> for EytzingerSearchSet<T>
+where
+    Q: ?Sized + Comparable<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T> SetIteration<T> for EytzingerSearchSet<T> {
@@ -62,13 +71,11 @@ impl<T> SetIteration<T> for EytzingerSearchSet<T> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T> Len for EytzingerSearchSet<T> {
-    fn len(&self) -> usize {
-        self.map.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST> BitOr<&ST> for &EytzingerSearchSet<T>
@@ -76,7 +83,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST> BitAnd<&ST> for &EytzingerSearchSet<T>
@@ -84,7 +91,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST> BitXor<&ST> for &EytzingerSearchSet<T>
@@ -92,7 +99,7 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST> Sub<&ST> for &EytzingerSearchSet<T>
@@ -100,23 +107,23 @@ where
     T: Hash + Ord + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T> IntoIterator for EytzingerSearchSet<T> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T> IntoIterator for &'a EytzingerSearchSet<T> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST> PartialEq<ST> for EytzingerSearchSet<T>
 where
     T: Ord,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T> Eq for EytzingerSearchSet<T> where T: Ord {}
@@ -125,7 +132,7 @@ impl<T> Debug for EytzingerSearchSet<T>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -133,5 +140,5 @@ impl<T> Serialize for EytzingerSearchSet<T>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/sets/iterators.rs
+++ b/frozen-collections-core/src/sets/iterators.rs
@@ -51,9 +51,7 @@ impl<T> FusedIterator for Iter<'_, T> {}
 
 impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
+        Self { inner: self.inner.clone() }
     }
 }
 
@@ -148,7 +146,6 @@ where
 {
     type Item = &'a T;
 
-    #[allow(clippy::needless_borrow)]
     #[mutants::skip]
     fn next(&mut self) -> Option<Self::Item> {
         if self.s1.len() > self.s2.len() {
@@ -159,7 +156,7 @@ where
 
             loop {
                 let item = self.s2_iter.next()?;
-                if !self.s1.contains(&item) {
+                if !self.s1.contains(item) {
                     return Some(item);
                 }
             }
@@ -171,7 +168,7 @@ where
 
             loop {
                 let item = self.s1_iter.next()?;
-                if !self.s2.contains(&item) {
+                if !self.s2.contains(item) {
                     return Some(item);
                 }
             }
@@ -283,9 +280,7 @@ where
     <S2 as SetIteration<T>>::Iterator<'a>: Clone,
 {
     fn clone(&self) -> Self {
-        Self {
-            iter: self.iter.clone(),
-        }
+        Self { iter: self.iter.clone() }
     }
 }
 
@@ -342,11 +337,10 @@ where
 {
     type Item = &'a T;
 
-    #[allow(clippy::needless_borrow)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let item = self.s1_iter.next()?;
-            if !self.s2.contains(&item) {
+            if !self.s2.contains(item) {
                 return Some(item);
             }
         }
@@ -429,20 +423,19 @@ where
 {
     type Item = &'a T;
 
-    #[allow(clippy::needless_borrow)]
     #[mutants::skip]
     fn next(&mut self) -> Option<Self::Item> {
         if self.s1.len() < self.s2.len() {
             loop {
                 let item = self.s1_iter.next()?;
-                if self.s2.contains(&item) {
+                if self.s2.contains(item) {
                     return Some(item);
                 }
             }
         } else {
             loop {
                 let item = self.s2_iter.next()?;
-                if self.s1.contains(&item) {
+                if self.s1.contains(item) {
                     return Some(item);
                 }
             }
@@ -495,8 +488,6 @@ where
 mod tests {
     use super::*;
     use crate::maps::{IntoIter as MapIntoIter, Iter as MapIter};
-    use alloc::string::String;
-    use alloc::vec::Vec;
     use alloc::{format, vec};
     use hashbrown::HashSet as HashbrownSet;
 
@@ -580,12 +571,8 @@ mod tests {
 
     #[test]
     fn test_union() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let union = Union::new(&set1, &set2);
 
         assert_eq!((2, Some(4)), union.size_hint());
@@ -607,12 +594,8 @@ mod tests {
 
     #[test]
     fn test_symmetric_difference() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let symmetric_difference = SymmetricDifference::new(&set1, &set2);
 
         assert_eq!((0, Some(4)), symmetric_difference.size_hint());
@@ -633,12 +616,8 @@ mod tests {
 
     #[test]
     fn test_difference() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let difference = Difference::new(&set1, &set2);
 
         assert_eq!((0, Some(2)), difference.size_hint());
@@ -659,12 +638,8 @@ mod tests {
 
     #[test]
     fn test_intersection() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let intersection = Intersection::new(&set1, &set2);
 
         assert_eq!((0, Some(2)), intersection.size_hint());
@@ -685,12 +660,8 @@ mod tests {
 
     #[test]
     fn test_difference_clone() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let difference = Difference::new(&set1, &set2);
         let difference_clone = difference.clone();
 
@@ -700,12 +671,8 @@ mod tests {
 
     #[test]
     fn test_intersection_clone() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let intersection = Intersection::new(&set1, &set2);
         let intersection_clone = intersection.clone();
 
@@ -715,12 +682,8 @@ mod tests {
 
     #[test]
     fn test_symmetric_difference_clone() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let symmetric_difference = SymmetricDifference::new(&set1, &set2);
         let symmetric_difference_clone = symmetric_difference.clone();
 
@@ -730,12 +693,8 @@ mod tests {
 
     #[test]
     fn test_union_clone() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let union = Union::new(&set1, &set2);
         let union_clone = union.clone();
 
@@ -746,12 +705,8 @@ mod tests {
 
     #[test]
     fn test_union_fmt() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let union = Union::new(&set1, &set2);
 
         let debug_str = format!("{union:?}");
@@ -762,12 +717,8 @@ mod tests {
 
     #[test]
     fn test_symmetric_difference_fmt() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let symmetric_difference = SymmetricDifference::new(&set1, &set2);
 
         let debug_str = format!("{symmetric_difference:?}");
@@ -777,12 +728,8 @@ mod tests {
 
     #[test]
     fn test_difference_fmt() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let difference = Difference::new(&set1, &set2);
 
         let debug_str = format!("{difference:?}");
@@ -791,12 +738,8 @@ mod tests {
 
     #[test]
     fn test_intersection_fmt() {
-        let set1 = vec!["Alice", "Bob"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
-        let set2 = vec!["Bob", "Charlie"]
-            .into_iter()
-            .collect::<HashbrownSet<_>>();
+        let set1 = vec!["Alice", "Bob"].into_iter().collect::<HashbrownSet<_>>();
+        let set2 = vec!["Bob", "Charlie"].into_iter().collect::<HashbrownSet<_>>();
         let intersection = Intersection::new(&set1, &set2);
 
         let debug_str = format!("{intersection:?}");

--- a/frozen-collections-core/src/sets/scan_set.rs
+++ b/frozen-collections-core/src/sets/scan_set.rs
@@ -1,10 +1,12 @@
 use crate::maps::ScanMap;
+use crate::maps::decl_macros::len_trait_funcs;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, into_iterator_ref_trait_funcs,
+    into_iterator_trait_funcs, partial_eq_trait_funcs, scan_primary_funcs, set_extras_trait_funcs, set_iteration_trait_funcs,
+    set_query_trait_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
@@ -12,7 +14,7 @@ use equivalent::Equivalent;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -27,32 +29,37 @@ pub struct ScanSet<T> {
     map: ScanMap<T, ()>,
 }
 
-impl<T> ScanSet<T>
-where
-    T: Eq,
-{
+impl<T> ScanSet<T> {
     /// Creates a frozen set.
     #[must_use]
     pub const fn new(map: ScanMap<T, ()>) -> Self {
         Self { map }
     }
+
+    scan_primary_funcs!();
+    common_primary_funcs!(non_const_len);
 }
 
 impl<T> Default for ScanSet<T> {
     fn default() -> Self {
-        Self {
-            map: ScanMap::default(),
-        }
+        Self { map: ScanMap::default() }
     }
 }
 
-impl<T, Q> Set<T, Q> for ScanSet<T> where Q: ?Sized + Eq + Equivalent<T> {}
+impl<T, Q> Set<T, Q> for ScanSet<T> where Q: ?Sized + Equivalent<T> {}
 
-impl<T, Q> SetQuery<T, Q> for ScanSet<T>
+impl<T, Q> SetExtras<T, Q> for ScanSet<T>
 where
-    Q: ?Sized + Eq + Equivalent<T>,
+    Q: ?Sized + Equivalent<T>,
 {
-    get_fn!();
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q> SetQuery<Q> for ScanSet<T>
+where
+    Q: ?Sized + Equivalent<T>,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T> SetIteration<T> for ScanSet<T> {
@@ -61,13 +68,11 @@ impl<T> SetIteration<T> for ScanSet<T> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T> Len for ScanSet<T> {
-    fn len(&self) -> usize {
-        self.map.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST> BitOr<&ST> for &ScanSet<T>
@@ -75,7 +80,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST> BitAnd<&ST> for &ScanSet<T>
@@ -83,7 +88,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST> BitXor<&ST> for &ScanSet<T>
@@ -91,7 +96,7 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST> Sub<&ST> for &ScanSet<T>
@@ -99,23 +104,23 @@ where
     T: Hash + Eq + Clone,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T> IntoIterator for ScanSet<T> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T> IntoIterator for &'a ScanSet<T> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST> PartialEq<ST> for ScanSet<T>
 where
-    T: Eq,
-    ST: Set<T>,
+    T: PartialEq,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T> Eq for ScanSet<T> where T: Eq {}
@@ -124,7 +129,7 @@ impl<T> Debug for ScanSet<T>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -132,5 +137,5 @@ impl<T> Serialize for ScanSet<T>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/sets/sparse_scalar_lookup_set.rs
+++ b/frozen-collections-core/src/sets/sparse_scalar_lookup_set.rs
@@ -1,17 +1,20 @@
 use crate::maps::SparseScalarLookupMap;
+use crate::maps::decl_macros::len_trait_funcs;
 use crate::sets::decl_macros::{
-    bitand_fn, bitor_fn, bitxor_fn, debug_fn, get_fn, into_iter_fn, into_iter_ref_fn,
-    partial_eq_fn, set_iteration_funcs, sub_fn,
+    bitand_trait_funcs, bitor_trait_funcs, bitxor_trait_funcs, common_primary_funcs, debug_trait_funcs, into_iterator_ref_trait_funcs,
+    into_iterator_trait_funcs, partial_eq_trait_funcs, set_extras_trait_funcs, set_iteration_trait_funcs, set_query_trait_funcs,
+    sparse_scalar_lookup_primary_funcs, sub_trait_funcs,
 };
 use crate::sets::{IntoIter, Iter};
-use crate::traits::{Len, MapIteration, MapQuery, Scalar, Set, SetIteration, SetOps, SetQuery};
+use crate::traits::{Len, Scalar, Set, SetExtras, SetIteration, SetOps, SetQuery};
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
+use equivalent::Comparable;
 
 #[cfg(feature = "serde")]
 use {
-    crate::sets::decl_macros::serialize_fn,
+    crate::sets::decl_macros::serialize_trait_funcs,
     serde::ser::SerializeSeq,
     serde::{Serialize, Serializer},
 };
@@ -26,10 +29,7 @@ pub struct SparseScalarLookupSet<T> {
     map: SparseScalarLookupMap<T, ()>,
 }
 
-impl<T> SparseScalarLookupSet<T>
-where
-    T: Scalar,
-{
+impl<T> SparseScalarLookupSet<T> {
     /// Creates a frozen set.
     ///
     /// # Errors
@@ -40,12 +40,12 @@ where
     pub const fn new(map: SparseScalarLookupMap<T, ()>) -> Self {
         Self { map }
     }
+
+    sparse_scalar_lookup_primary_funcs!();
+    common_primary_funcs!(non_const_len);
 }
 
-impl<T> Default for SparseScalarLookupSet<T>
-where
-    T: Scalar,
-{
+impl<T> Default for SparseScalarLookupSet<T> {
     fn default() -> Self {
         Self {
             map: SparseScalarLookupMap::default(),
@@ -53,13 +53,20 @@ where
     }
 }
 
-impl<T> Set<T, T> for SparseScalarLookupSet<T> where T: Scalar {}
+impl<T, Q> Set<T, Q> for SparseScalarLookupSet<T> where Q: Comparable<T> + Scalar {}
 
-impl<T> SetQuery<T, T> for SparseScalarLookupSet<T>
+impl<T, Q> SetExtras<T, Q> for SparseScalarLookupSet<T>
 where
-    T: Scalar,
+    Q: Comparable<T> + Scalar,
 {
-    get_fn!("Scalar");
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q> SetQuery<Q> for SparseScalarLookupSet<T>
+where
+    Q: Comparable<T> + Scalar,
+{
+    set_query_trait_funcs!();
 }
 
 impl<T> SetIteration<T> for SparseScalarLookupSet<T> {
@@ -68,13 +75,11 @@ impl<T> SetIteration<T> for SparseScalarLookupSet<T> {
     where
         T: 'a;
 
-    set_iteration_funcs!();
+    set_iteration_trait_funcs!();
 }
 
 impl<T> Len for SparseScalarLookupSet<T> {
-    fn len(&self) -> usize {
-        self.map.len()
-    }
+    len_trait_funcs!();
 }
 
 impl<T, ST> BitOr<&ST> for &SparseScalarLookupSet<T>
@@ -82,7 +87,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitor_fn!();
+    bitor_trait_funcs!();
 }
 
 impl<T, ST> BitAnd<&ST> for &SparseScalarLookupSet<T>
@@ -90,7 +95,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitand_fn!();
+    bitand_trait_funcs!();
 }
 
 impl<T, ST> BitXor<&ST> for &SparseScalarLookupSet<T>
@@ -98,7 +103,7 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    bitxor_fn!();
+    bitxor_trait_funcs!();
 }
 
 impl<T, ST> Sub<&ST> for &SparseScalarLookupSet<T>
@@ -106,23 +111,23 @@ where
     T: Scalar + Hash,
     ST: Set<T>,
 {
-    sub_fn!();
+    sub_trait_funcs!();
 }
 
 impl<T> IntoIterator for SparseScalarLookupSet<T> {
-    into_iter_fn!();
+    into_iterator_trait_funcs!();
 }
 
 impl<'a, T> IntoIterator for &'a SparseScalarLookupSet<T> {
-    into_iter_ref_fn!();
+    into_iterator_ref_trait_funcs!();
 }
 
 impl<T, ST> PartialEq<ST> for SparseScalarLookupSet<T>
 where
     T: Scalar,
-    ST: Set<T>,
+    ST: SetQuery<T>,
 {
-    partial_eq_fn!();
+    partial_eq_trait_funcs!();
 }
 
 impl<T> Eq for SparseScalarLookupSet<T> where T: Scalar {}
@@ -131,7 +136,7 @@ impl<T> Debug for SparseScalarLookupSet<T>
 where
     T: Debug,
 {
-    debug_fn!();
+    debug_trait_funcs!();
 }
 
 #[cfg(feature = "serde")]
@@ -139,5 +144,5 @@ impl<T> Serialize for SparseScalarLookupSet<T>
 where
     T: Serialize,
 {
-    serialize_fn!();
+    serialize_trait_funcs!();
 }

--- a/frozen-collections-core/src/traits/len.rs
+++ b/frozen-collections-core/src/traits/len.rs
@@ -1,16 +1,16 @@
-use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::rc::Rc;
-use alloc::string::String;
 use alloc::sync::Arc;
-use alloc::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::string::String, alloc::vec::Vec};
 
 /// Types that can return a length.
 pub trait Len {
-    /// Returns the length of the value.
+    #[doc = include_str!("../doc_snippets/len.md")]
     fn len(&self) -> usize;
 
-    /// Returns whether the value is empty.
+    #[doc = include_str!("../doc_snippets/is_empty.md")]
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -103,35 +103,35 @@ impl<K, V, CM> Len for std::collections::HashMap<K, V, CM> {
 }
 
 #[cfg(feature = "std")]
-impl Len for std::ffi::CString {
+impl Len for alloc::ffi::CString {
     fn len(&self) -> usize {
         self.as_bytes().len()
     }
 }
 
 #[cfg(feature = "std")]
-impl<K, V> Len for std::collections::BTreeMap<K, V> {
+impl<K, V> Len for alloc::collections::BTreeMap<K, V> {
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> Len for std::collections::BTreeSet<T> {
+impl<T> Len for alloc::collections::BTreeSet<T> {
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> Len for std::collections::BinaryHeap<T> {
+impl<T> Len for alloc::collections::BinaryHeap<T> {
     fn len(&self) -> usize {
         self.len()
     }
 }
 
 #[cfg(feature = "std")]
-impl<T> Len for std::collections::LinkedList<T> {
+impl<T> Len for alloc::collections::LinkedList<T> {
     fn len(&self) -> usize {
         self.len()
     }
@@ -154,13 +154,10 @@ impl Len for std::ffi::OsString {
 #[cfg(test)]
 mod tests {
     use crate::traits::Len;
-    use alloc::boxed::Box;
     use alloc::collections::VecDeque;
     use alloc::rc::Rc;
-    use alloc::string::String;
     use alloc::sync::Arc;
     use alloc::vec;
-    use alloc::vec::Vec;
 
     fn get_len<T: Len + ?Sized>(value: &T) -> usize {
         value.len()
@@ -237,7 +234,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn cstring_len_and_is_empty() {
-        use std::ffi::CString;
+        use alloc::ffi::CString;
         let s = CString::new("").unwrap();
         assert_eq!(get_len(&s), 0);
         assert!(s.is_empty());
@@ -317,7 +314,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn btreemap_len_and_is_empty() {
-        use std::collections::BTreeMap;
+        use alloc::collections::BTreeMap;
         let mut map = BTreeMap::new();
         assert_eq!(get_len(&map), 0);
         assert!(map.is_empty());
@@ -330,7 +327,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn btreeset_len_and_is_empty() {
-        use std::collections::BTreeSet;
+        use alloc::collections::BTreeSet;
         let mut set = BTreeSet::new();
         assert_eq!(get_len(&set), 0);
         assert!(set.is_empty());
@@ -343,7 +340,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn binaryheap_len_and_is_empty() {
-        use std::collections::BinaryHeap;
+        use alloc::collections::BinaryHeap;
         let mut heap = BinaryHeap::new();
         assert_eq!(get_len(&heap), 0);
         assert!(heap.is_empty());
@@ -356,7 +353,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn linkedlist_len_and_is_empty() {
-        use std::collections::LinkedList;
+        use alloc::collections::LinkedList;
         let mut list = LinkedList::new();
         assert_eq!(get_len(&list), 0);
         assert!(list.is_empty());

--- a/frozen-collections-core/src/traits/map.rs
+++ b/frozen-collections-core/src/traits/map.rs
@@ -1,35 +1,11 @@
-use crate::traits::{Len, MapIteration, MapQuery};
-use core::borrow::Borrow;
+use crate::traits::{MapExtras, MapIteration, MapQuery};
 use core::hash::{BuildHasher, Hash};
 
 #[cfg(feature = "std")]
-use core::mem::MaybeUninit;
-
-#[cfg(feature = "std")]
-use crate::utils::cold;
+use core::borrow::Borrow;
 
 /// Common abstractions for maps.
-pub trait Map<K, V, Q: ?Sized = K>: MapQuery<K, V, Q> + MapIteration<K, V> + Len {
-    /// Gets multiple mutable values from the map.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the same key is specified multiple times.
-    #[must_use]
-    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N];
-
-    /// Gets multiple mutable values from the map.
-    ///
-    /// # Safety
-    ///     
-    /// Calling this method with overlapping keys is [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html)
-    /// even if the resulting references are not used.
-    #[must_use]
-    unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-        &mut self,
-        keys: [&Q; N],
-    ) -> [Option<&mut V>; N];
-}
+pub trait Map<K, V, Q: ?Sized = K>: MapQuery<Q, V> + MapIteration<K, V> + MapExtras<K, V, Q> {}
 
 #[cfg(feature = "std")]
 impl<K, V, Q, BH> Map<K, V, Q> for std::collections::HashMap<K, V, BH>
@@ -38,64 +14,20 @@ where
     Q: ?Sized + Hash + Eq,
     BH: BuildHasher,
 {
-    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
-        Self::get_disjoint_mut(self, keys)
-    }
-
-    unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-        &mut self,
-        keys: [&Q; N],
-    ) -> [Option<&mut V>; N] {
-        unsafe { Self::get_disjoint_unchecked_mut(self, keys) }
-    }
 }
 
 #[cfg(feature = "std")]
-impl<K, V, Q> Map<K, V, Q> for std::collections::BTreeMap<K, V>
+impl<K, V, Q> Map<K, V, Q> for alloc::collections::BTreeMap<K, V>
 where
     K: Ord + Borrow<Q>,
     Q: Ord,
 {
-    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
-        if crate::utils::has_duplicates_slow(&keys) {
-            cold();
-            panic!("duplicate keys found");
-        }
-
-        unsafe { self.get_disjoint_unchecked_mut(keys) }
-    }
-
-    unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-        &mut self,
-        keys: [&Q; N],
-    ) -> [Option<&mut V>; N] {
-        let mut result: MaybeUninit<[Option<&mut V>; N]> = MaybeUninit::uninit();
-        let p = result.as_mut_ptr();
-        let x: *mut Self = self;
-        unsafe {
-            for (i, key) in keys.iter().enumerate() {
-                (*p)[i] = (*x).get_mut(key);
-            }
-
-            result.assume_init()
-        }
-    }
 }
 
 impl<K, V, Q, BH> Map<K, V, Q> for hashbrown::HashMap<K, V, BH>
 where
-    K: Hash + Eq + Borrow<Q>,
-    Q: Hash + Eq,
+    K: Hash + Eq,
+    Q: ?Sized + Hash + Eq + hashbrown::Equivalent<K>,
     BH: BuildHasher,
 {
-    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
-        Self::get_many_mut(self, keys)
-    }
-
-    unsafe fn get_disjoint_unchecked_mut<const N: usize>(
-        &mut self,
-        keys: [&Q; N],
-    ) -> [Option<&mut V>; N] {
-        unsafe { Self::get_many_unchecked_mut(self, keys) }
-    }
 }

--- a/frozen-collections-core/src/traits/map_extras.rs
+++ b/frozen-collections-core/src/traits/map_extras.rs
@@ -1,0 +1,73 @@
+use core::hash::{BuildHasher, Hash};
+
+#[cfg(feature = "std")]
+use {
+    crate::maps::decl_macros::{get_disjoint_mut_funcs, map_extras_trait_funcs},
+    core::borrow::Borrow,
+};
+
+/// Extra abstractions for maps.
+pub trait MapExtras<K, V, Q: ?Sized = K> {
+    #[doc = include_str!("../doc_snippets/get_key_value.md")]
+    #[must_use]
+    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)>;
+
+    #[doc = include_str!("../doc_snippets/get_disjoint_mut.md")]
+    #[must_use]
+    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
+    where
+        Q: Eq;
+
+    #[doc = include_str!("../doc_snippets/get_disjoint_unchecked_mut.md")]
+    #[must_use]
+    unsafe fn get_disjoint_unchecked_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N];
+}
+
+#[cfg(feature = "std")]
+impl<K, V, Q, BH> MapExtras<K, V, Q> for std::collections::HashMap<K, V, BH>
+where
+    K: Hash + Eq + Borrow<Q>,
+    Q: ?Sized + Hash + Eq,
+    BH: BuildHasher,
+{
+    map_extras_trait_funcs!();
+}
+
+#[cfg(feature = "std")]
+impl<K, V, Q> MapExtras<K, V, Q> for alloc::collections::BTreeMap<K, V>
+where
+    K: Ord + Borrow<Q>,
+    Q: ?Sized + Ord,
+{
+    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
+        self.get_key_value(key)
+    }
+
+    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
+        get_disjoint_mut_funcs!(@safe_body, self, keys);
+    }
+
+    unsafe fn get_disjoint_unchecked_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
+        get_disjoint_mut_funcs!(@unsafe_body, self, keys);
+    }
+}
+
+impl<K, V, Q, BH> MapExtras<K, V, Q> for hashbrown::HashMap<K, V, BH>
+where
+    K: Hash + Eq,
+    Q: ?Sized + Hash + hashbrown::Equivalent<K>,
+    BH: BuildHasher,
+{
+    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
+        self.get_key_value(key)
+    }
+
+    fn get_disjoint_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
+        self.get_many_mut(keys)
+    }
+
+    unsafe fn get_disjoint_unchecked_mut<const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N] {
+        // SAFETY: This method is unsafe because it assumes that the keys are disjoint and valid.
+        unsafe { self.get_many_unchecked_mut(keys) }
+    }
+}

--- a/frozen-collections-core/src/traits/map_iteration.rs
+++ b/frozen-collections-core/src/traits/map_iteration.rs
@@ -2,63 +2,71 @@ use core::hash::BuildHasher;
 
 /// Common iteration abstractions for maps.
 pub trait MapIteration<K, V>: IntoIterator<Item = (K, V)> {
+    /// The type of the iterator returned by [`Self::iter`].
     type Iterator<'a>: Iterator<Item = (&'a K, &'a V)>
     where
         Self: 'a,
         K: 'a,
         V: 'a;
 
+    /// The type of the iterator returned by [`Self::keys`].
     type KeyIterator<'a>: Iterator<Item = &'a K>
     where
         Self: 'a,
         K: 'a;
 
+    /// The type of the iterator returned by [`Self::values`].
     type ValueIterator<'a>: Iterator<Item = &'a V>
     where
         Self: 'a,
         V: 'a;
 
+    /// The type of the iterator returned by [`Self::into_keys`].
     type IntoKeyIterator: Iterator<Item = K>;
+
+    /// The type of the iterator returned by [`Self::into_values`].
     type IntoValueIterator: Iterator<Item = V>;
 
+    /// The type of the mutable iterator returned by [`Self::iter_mut`].
     type MutIterator<'a>: Iterator<Item = (&'a K, &'a mut V)>
     where
         Self: 'a,
         K: 'a,
         V: 'a;
 
+    /// The type of the mutable iterator returned by [`Self::values_mut`].
     type ValueMutIterator<'a>: Iterator<Item = &'a mut V>
     where
         Self: 'a,
         V: 'a;
 
-    /// An iterator visiting all entries in arbitrary order.
+    #[doc = include_str!("../doc_snippets/iter.md")]
     #[must_use]
     fn iter(&self) -> Self::Iterator<'_>;
 
-    /// An iterator visiting all keys in arbitrary order.
-    #[must_use]
-    fn keys(&self) -> Self::KeyIterator<'_>;
-
-    /// An iterator visiting all values in arbitrary order.
-    #[must_use]
-    fn values(&self) -> Self::ValueIterator<'_>;
-
-    /// A consuming iterator visiting all keys in arbitrary order.
-    #[must_use]
-    fn into_keys(self) -> Self::IntoKeyIterator;
-
-    /// A consuming iterator visiting all values in arbitrary order.
-    #[must_use]
-    fn into_values(self) -> Self::IntoValueIterator;
-
-    /// An iterator producing mutable references to all entries in arbitrary order.
+    #[doc = include_str!("../doc_snippets/iter_mut.md")]
     #[must_use]
     fn iter_mut(&mut self) -> Self::MutIterator<'_>;
 
-    /// An iterator visiting all values mutably in arbitrary order.
+    #[doc = include_str!("../doc_snippets/keys.md")]
+    #[must_use]
+    fn keys(&self) -> Self::KeyIterator<'_>;
+
+    #[doc = include_str!("../doc_snippets/into_keys.md")]
+    #[must_use]
+    fn into_keys(self) -> Self::IntoKeyIterator;
+
+    #[doc = include_str!("../doc_snippets/values.md")]
+    #[must_use]
+    fn values(&self) -> Self::ValueIterator<'_>;
+
+    #[doc = include_str!("../doc_snippets/values_mut.md")]
     #[must_use]
     fn values_mut(&mut self) -> Self::ValueMutIterator<'_>;
+
+    #[doc = include_str!("../doc_snippets/into_values.md")]
+    #[must_use]
+    fn into_values(self) -> Self::IntoValueIterator;
 }
 
 #[cfg(feature = "std")]
@@ -89,6 +97,7 @@ where
 
     type IntoKeyIterator = std::collections::hash_map::IntoKeys<K, V>;
     type IntoValueIterator = std::collections::hash_map::IntoValues<K, V>;
+
     type MutIterator<'a>
         = std::collections::hash_map::IterMut<'a, K, V>
     where
@@ -104,94 +113,95 @@ where
         BH: 'a;
 
     fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
-
-    fn keys(&self) -> Self::KeyIterator<'_> {
-        Self::keys(self)
-    }
-
-    fn values(&self) -> Self::ValueIterator<'_> {
-        Self::values(self)
-    }
-
-    fn into_keys(self) -> Self::IntoKeyIterator {
-        Self::into_keys(self)
-    }
-
-    fn into_values(self) -> Self::IntoValueIterator {
-        Self::into_values(self)
+        self.iter()
     }
 
     fn iter_mut(&mut self) -> Self::MutIterator<'_> {
-        Self::iter_mut(self)
+        self.iter_mut()
+    }
+
+    fn keys(&self) -> Self::KeyIterator<'_> {
+        self.keys()
+    }
+
+    fn into_keys(self) -> Self::IntoKeyIterator {
+        self.into_keys()
+    }
+
+    fn values(&self) -> Self::ValueIterator<'_> {
+        self.values()
     }
 
     fn values_mut(&mut self) -> Self::ValueMutIterator<'_> {
         self.values_mut()
     }
+
+    fn into_values(self) -> Self::IntoValueIterator {
+        self.into_values()
+    }
 }
 
 #[cfg(feature = "std")]
-impl<K, V> MapIteration<K, V> for std::collections::BTreeMap<K, V> {
+impl<K, V> MapIteration<K, V> for alloc::collections::BTreeMap<K, V> {
     type Iterator<'a>
-        = std::collections::btree_map::Iter<'a, K, V>
+        = alloc::collections::btree_map::Iter<'a, K, V>
     where
         K: 'a,
         V: 'a;
 
     type KeyIterator<'a>
-        = std::collections::btree_map::Keys<'a, K, V>
+        = alloc::collections::btree_map::Keys<'a, K, V>
     where
         K: 'a,
         V: 'a;
 
     type ValueIterator<'a>
-        = std::collections::btree_map::Values<'a, K, V>
+        = alloc::collections::btree_map::Values<'a, K, V>
     where
         K: 'a,
         V: 'a;
 
-    type IntoKeyIterator = std::collections::btree_map::IntoKeys<K, V>;
-    type IntoValueIterator = std::collections::btree_map::IntoValues<K, V>;
+    type IntoKeyIterator = alloc::collections::btree_map::IntoKeys<K, V>;
+    type IntoValueIterator = alloc::collections::btree_map::IntoValues<K, V>;
+
     type MutIterator<'a>
-        = std::collections::btree_map::IterMut<'a, K, V>
+        = alloc::collections::btree_map::IterMut<'a, K, V>
     where
         K: 'a,
         V: 'a;
 
     type ValueMutIterator<'a>
-        = std::collections::btree_map::ValuesMut<'a, K, V>
+        = alloc::collections::btree_map::ValuesMut<'a, K, V>
     where
         K: 'a,
         V: 'a;
 
     fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
-
-    fn keys(&self) -> Self::KeyIterator<'_> {
-        Self::keys(self)
-    }
-
-    fn values(&self) -> Self::ValueIterator<'_> {
-        Self::values(self)
-    }
-
-    fn into_keys(self) -> Self::IntoKeyIterator {
-        Self::into_keys(self)
-    }
-
-    fn into_values(self) -> Self::IntoValueIterator {
-        Self::into_values(self)
+        self.iter()
     }
 
     fn iter_mut(&mut self) -> Self::MutIterator<'_> {
-        Self::iter_mut(self)
+        self.iter_mut()
+    }
+
+    fn keys(&self) -> Self::KeyIterator<'_> {
+        self.keys()
+    }
+
+    fn into_keys(self) -> Self::IntoKeyIterator {
+        self.into_keys()
+    }
+
+    fn values(&self) -> Self::ValueIterator<'_> {
+        self.values()
     }
 
     fn values_mut(&mut self) -> Self::ValueMutIterator<'_> {
         self.values_mut()
+    }
+
+    fn into_values(self) -> Self::IntoValueIterator {
+        self.into_values()
     }
 }
 
@@ -222,6 +232,7 @@ where
 
     type IntoKeyIterator = hashbrown::hash_map::IntoKeys<K, V>;
     type IntoValueIterator = hashbrown::hash_map::IntoValues<K, V>;
+
     type MutIterator<'a>
         = hashbrown::hash_map::IterMut<'a, K, V>
     where
@@ -237,30 +248,30 @@ where
         BH: 'a;
 
     fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
-
-    fn keys(&self) -> Self::KeyIterator<'_> {
-        Self::keys(self)
-    }
-
-    fn values(&self) -> Self::ValueIterator<'_> {
-        Self::values(self)
-    }
-
-    fn into_keys(self) -> Self::IntoKeyIterator {
-        Self::into_keys(self)
-    }
-
-    fn into_values(self) -> Self::IntoValueIterator {
-        Self::into_values(self)
+        self.iter()
     }
 
     fn iter_mut(&mut self) -> Self::MutIterator<'_> {
-        Self::iter_mut(self)
+        self.iter_mut()
+    }
+
+    fn keys(&self) -> Self::KeyIterator<'_> {
+        self.keys()
+    }
+
+    fn into_keys(self) -> Self::IntoKeyIterator {
+        self.into_keys()
+    }
+
+    fn values(&self) -> Self::ValueIterator<'_> {
+        self.values()
     }
 
     fn values_mut(&mut self) -> Self::ValueMutIterator<'_> {
         self.values_mut()
+    }
+
+    fn into_values(self) -> Self::IntoValueIterator {
+        self.into_values()
     }
 }

--- a/frozen-collections-core/src/traits/map_query.rs
+++ b/frozen-collections-core/src/traits/map_query.rs
@@ -1,107 +1,51 @@
+use crate::maps::decl_macros::map_query_trait_funcs;
+use crate::traits::Len;
 use core::hash::{BuildHasher, Hash};
 
-/// Common query abstractions for maps.
-pub trait MapQuery<K, V, Q: ?Sized = K> {
-    /// Checks whether a particular value is present in the map.
-    #[inline]
-    #[must_use]
-    fn contains_key(&self, key: &Q) -> bool {
-        self.get(key).is_some()
-    }
+#[cfg(feature = "std")]
+use core::borrow::Borrow;
 
-    /// Gets a value from the map.
+/// Common query abstractions for maps.
+pub trait MapQuery<Q: ?Sized, V>: Len {
+    #[doc = include_str!("../doc_snippets/get.md")]
     #[must_use]
     fn get(&self, key: &Q) -> Option<&V>;
 
-    /// Gets a key and value from the map.
-    #[must_use]
-    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)>;
-
-    /// Gets a mutable value from the map.
+    #[doc = include_str!("../doc_snippets/get_mut.md")]
     #[must_use]
     fn get_mut(&mut self, key: &Q) -> Option<&mut V>;
+
+    #[doc = include_str!("../doc_snippets/contains_key.md")]
+    #[must_use]
+    fn contains_key(&self, key: &Q) -> bool;
 }
 
 #[cfg(feature = "std")]
-impl<K, V, Q, BH> MapQuery<K, V, Q> for std::collections::HashMap<K, V, BH>
+impl<K, V, Q, BH> MapQuery<Q, V> for std::collections::HashMap<K, V, BH>
 where
-    K: Hash + Eq + core::borrow::Borrow<Q>,
+    K: Hash + Eq + Borrow<Q>,
     Q: ?Sized + Hash + Eq,
     BH: BuildHasher,
 {
-    #[inline]
-    fn contains_key(&self, key: &Q) -> bool {
-        Self::contains_key(self, key)
-    }
-
-    #[inline]
-    fn get(&self, key: &Q) -> Option<&V> {
-        Self::get(self, key)
-    }
-
-    #[inline]
-    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-        Self::get_key_value(self, key)
-    }
-
-    #[inline]
-    fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-        Self::get_mut(self, key)
-    }
+    map_query_trait_funcs!();
 }
 
 #[cfg(feature = "std")]
-impl<K, V, Q> MapQuery<K, V, Q> for std::collections::BTreeMap<K, V>
+impl<K, V, Q> MapQuery<Q, V> for alloc::collections::BTreeMap<K, V>
 where
-    K: Ord + core::borrow::Borrow<Q>,
-    Q: Ord,
+    K: Ord + Borrow<Q>,
+    Q: ?Sized + Ord,
 {
-    #[inline]
-    fn contains_key(&self, key: &Q) -> bool {
-        Self::contains_key(self, key)
-    }
-
-    #[inline]
-    fn get(&self, key: &Q) -> Option<&V> {
-        Self::get(self, key)
-    }
-
-    #[inline]
-    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-        Self::get_key_value(self, key)
-    }
-
-    #[inline]
-    fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-        Self::get_mut(self, key)
-    }
+    map_query_trait_funcs!();
 }
 
-impl<K, V, Q, BH> MapQuery<K, V, Q> for hashbrown::HashMap<K, V, BH>
+impl<K, V, Q, BH> MapQuery<Q, V> for hashbrown::HashMap<K, V, BH>
 where
-    K: Hash + Eq + core::borrow::Borrow<Q>,
-    Q: Hash + Eq,
+    K: Hash + Eq,
+    Q: ?Sized + Hash + Eq + hashbrown::Equivalent<K>,
     BH: BuildHasher,
 {
-    #[inline]
-    fn contains_key(&self, key: &Q) -> bool {
-        Self::contains_key(self, key)
-    }
-
-    #[inline]
-    fn get(&self, key: &Q) -> Option<&V> {
-        Self::get(self, key)
-    }
-
-    #[inline]
-    fn get_key_value(&self, key: &Q) -> Option<(&K, &V)> {
-        Self::get_key_value(self, key)
-    }
-
-    #[inline]
-    fn get_mut(&mut self, key: &Q) -> Option<&mut V> {
-        Self::get_mut(self, key)
-    }
+    map_query_trait_funcs!();
 }
 
 #[cfg(test)]
@@ -111,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_object_safe() {
-        let m: &dyn MapQuery<_, _, _> = &HashMap::from([(1, 1), (2, 2), (3, 3)]);
+        let m: &dyn MapQuery<_, _> = &HashMap::from([(1, 1), (2, 2), (3, 3)]);
 
         assert!(m.contains_key(&1));
     }

--- a/frozen-collections-core/src/traits/mod.rs
+++ b/frozen-collections-core/src/traits/mod.rs
@@ -1,15 +1,15 @@
 //! Traits to support frozen collections.
 
-pub use crate::traits::collection_magnitude::{
-    CollectionMagnitude, LargeCollection, MediumCollection, SmallCollection,
-};
+pub use crate::traits::collection_magnitude::{CollectionMagnitude, LargeCollection, MediumCollection, SmallCollection};
 pub use crate::traits::hasher::Hasher;
 pub use crate::traits::len::Len;
 pub use crate::traits::map::Map;
+pub use crate::traits::map_extras::MapExtras;
 pub use crate::traits::map_iteration::MapIteration;
 pub use crate::traits::map_query::MapQuery;
 pub use crate::traits::scalar::Scalar;
 pub use crate::traits::set::Set;
+pub use crate::traits::set_extras::SetExtras;
 pub use crate::traits::set_iteration::SetIteration;
 pub use crate::traits::set_ops::SetOps;
 pub use crate::traits::set_query::SetQuery;
@@ -18,10 +18,12 @@ mod collection_magnitude;
 mod hasher;
 mod len;
 mod map;
+mod map_extras;
 mod map_iteration;
 mod map_query;
 mod scalar;
 mod set;
+mod set_extras;
 mod set_iteration;
 mod set_ops;
 mod set_query;

--- a/frozen-collections-core/src/traits/scalar.rs
+++ b/frozen-collections-core/src/traits/scalar.rs
@@ -1,7 +1,4 @@
-use core::num::{
-    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32,
-    NonZeroUsize,
-};
+use core::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroUsize};
 
 /// A scalar value with an index in its sequence of possible values.
 pub trait Scalar: Ord + Clone + Copy {
@@ -14,8 +11,8 @@ macro_rules! impl_unsigned_scalar {
         $(
             impl Scalar for $t {
                 #[inline]
-                #[allow(clippy::cast_possible_truncation)]
-                #[allow(trivial_numeric_casts)]
+                #[allow(clippy::cast_possible_truncation, reason = "Normal")]
+                #[allow(trivial_numeric_casts, reason = "Normal")]
                 fn index(&self) -> usize {
                     *self as usize
                 }
@@ -29,9 +26,9 @@ macro_rules! impl_signed_scalar {
         $(
             impl Scalar for $t {
                 #[inline]
-                #[allow(clippy::cast_sign_loss)]
-                #[allow(clippy::cast_possible_truncation)]
-                #[allow(trivial_numeric_casts)]
+                #[allow(clippy::cast_sign_loss, reason = "Normal")]
+                #[allow(clippy::cast_possible_truncation, reason = "Normal")]
+                #[allow(trivial_numeric_casts, reason = "Normal")]
                 fn index(&self) -> usize {
                     ((*self as $unsigned_ty) ^ $mask) as usize
                 }
@@ -45,8 +42,8 @@ macro_rules! impl_unsigned_nz_scalar {
         $(
             impl Scalar for $t {
                 #[inline]
-                #[allow(clippy::cast_possible_truncation)]
-                #[allow(trivial_numeric_casts)]
+                #[allow(clippy::cast_possible_truncation, reason = "Normal")]
+                #[allow(trivial_numeric_casts, reason = "Normal")]
                 fn index(&self) -> usize {
                     (*self).get() as usize
                 }
@@ -60,9 +57,9 @@ macro_rules! impl_signed_nz_scalar {
         $(
             impl Scalar for $t {
                 #[inline]
-                #[allow(clippy::cast_sign_loss)]
-                #[allow(clippy::cast_possible_truncation)]
-                #[allow(trivial_numeric_casts)]
+                #[allow(clippy::cast_sign_loss, reason = "Normal")]
+                #[allow(clippy::cast_possible_truncation, reason = "Normal")]
+                #[allow(trivial_numeric_casts, reason = "Normal")]
                 fn index(&self) -> usize {
                     (((*self).get() as $unsigned_ty) ^ $mask) as usize
                 }
@@ -76,13 +73,7 @@ impl_unsigned_scalar!(u8, u16, u32, u64, usize);
 #[cfg(target_pointer_width = "64")]
 impl_signed_scalar!(i8:u8:0x80, i16:u16:0x8000, i32:u32:0x8000_0000, i64:u64:0x8000_0000_0000_0000, isize:usize:0x8000_0000_0000_0000);
 #[cfg(target_pointer_width = "64")]
-impl_unsigned_nz_scalar!(
-    NonZeroU8,
-    NonZeroU16,
-    NonZeroU32,
-    core::num::NonZeroU64,
-    NonZeroUsize
-);
+impl_unsigned_nz_scalar!(NonZeroU8, NonZeroU16, NonZeroU32, core::num::NonZeroU64, NonZeroUsize);
 #[cfg(target_pointer_width = "64")]
 impl_signed_nz_scalar!(NonZeroI8:u8:0x80, NonZeroI16:u16:0x8000, NonZeroI32:u32:0x8000_0000, core::num::NonZeroI64:u64:0x8000_0000_0000_0000, NonZeroIsize:usize:0x8000_0000_0000_0000);
 
@@ -101,44 +92,44 @@ mod tests {
 
     #[test]
     fn test_unsigned_scalar() {
-        assert_eq!(5u8.index(), 5);
-        assert_eq!(10u16.index(), 10);
-        assert_eq!(20u32.index(), 20);
-        assert_eq!(30usize.index(), 30);
+        assert_eq!(5_u8.index(), 5);
+        assert_eq!(10_u16.index(), 10);
+        assert_eq!(20_u32.index(), 20);
+        assert_eq!(30_usize.index(), 30);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_unsigned_scalar_64() {
-        assert_eq!(40u64.index(), 40);
+        assert_eq!(40_u64.index(), 40);
     }
 
     #[test]
     fn test_signed_scalar() {
-        assert_eq!((-5i8).index(), 0x80 - 5);
-        assert_eq!((-10i16).index(), 0x8000 - 10);
-        assert_eq!((-20i32).index(), 0x8000_0000 - 20);
+        assert_eq!((-5_i8).index(), 0x80 - 5);
+        assert_eq!((-10_i16).index(), 0x8000 - 10);
+        assert_eq!((-20_i32).index(), 0x8000_0000 - 20);
 
-        assert_eq!(5i8.index(), 0x80 + 5);
-        assert_eq!(10i16.index(), 0x8000 + 10);
-        assert_eq!(20i32.index(), 0x8000_0000 + 20);
+        assert_eq!(5_i8.index(), 0x80 + 5);
+        assert_eq!(10_i16.index(), 0x8000 + 10);
+        assert_eq!(20_i32.index(), 0x8000_0000 + 20);
     }
 
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn test_signed_scalar_32() {
-        assert_eq!((-30isize).index(), 0x8000_0000 - 30);
-        assert_eq!(30isize.index(), 0x8000_0000 + 30);
+        assert_eq!((-30_isize).index(), 0x8000_0000 - 30);
+        assert_eq!(30_isize.index(), 0x8000_0000 + 30);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_signed_scalar_64() {
-        assert_eq!((-30isize).index(), 0x8000_0000_0000_0000 - 30);
-        assert_eq!((-40i64).index(), 0x8000_0000_0000_0000 - 40);
+        assert_eq!((-30_isize).index(), 0x8000_0000_0000_0000 - 30);
+        assert_eq!((-40_i64).index(), 0x8000_0000_0000_0000 - 40);
 
-        assert_eq!(30isize.index(), 0x8000_0000_0000_0000 + 30);
-        assert_eq!(40i64.index(), 0x8000_0000_0000_0000 + 40);
+        assert_eq!(30_isize.index(), 0x8000_0000_0000_0000 + 30);
+        assert_eq!(40_i64.index(), 0x8000_0000_0000_0000 + 40);
     }
 
     #[test]
@@ -176,22 +167,10 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_signed_nz_scalar_64() {
-        assert_eq!(
-            NonZeroIsize::new(-30).unwrap().index(),
-            0x8000_0000_0000_0000 - 30
-        );
-        assert_eq!(
-            core::num::NonZeroI64::new(-40).unwrap().index(),
-            0x8000_0000_0000_0000 - 40
-        );
+        assert_eq!(NonZeroIsize::new(-30).unwrap().index(), 0x8000_0000_0000_0000 - 30);
+        assert_eq!(core::num::NonZeroI64::new(-40).unwrap().index(), 0x8000_0000_0000_0000 - 40);
 
-        assert_eq!(
-            NonZeroIsize::new(30).unwrap().index(),
-            0x8000_0000_0000_0000 + 30
-        );
-        assert_eq!(
-            core::num::NonZeroI64::new(40).unwrap().index(),
-            0x8000_0000_0000_0000 + 40
-        );
+        assert_eq!(NonZeroIsize::new(30).unwrap().index(), 0x8000_0000_0000_0000 + 30);
+        assert_eq!(core::num::NonZeroI64::new(40).unwrap().index(), 0x8000_0000_0000_0000 + 40);
     }
 }

--- a/frozen-collections-core/src/traits/set.rs
+++ b/frozen-collections-core/src/traits/set.rs
@@ -1,9 +1,11 @@
-use crate::traits::{Len, SetIteration, SetQuery};
-use core::borrow::Borrow;
+use crate::traits::{SetExtras, SetIteration, SetQuery};
 use core::hash::{BuildHasher, Hash};
 
+#[cfg(feature = "std")]
+use core::borrow::Borrow;
+
 /// Common abstractions for sets.
-pub trait Set<T, Q: ?Sized = T>: SetQuery<T, Q> + SetIteration<T> + Len {}
+pub trait Set<T, Q: ?Sized = T>: SetQuery<Q> + SetIteration<T> + SetExtras<T, Q> {}
 
 #[cfg(feature = "std")]
 impl<T, Q, BH> Set<T, Q> for std::collections::HashSet<T, BH>
@@ -15,7 +17,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<T, Q> Set<T, Q> for std::collections::BTreeSet<T>
+impl<T, Q> Set<T, Q> for alloc::collections::BTreeSet<T>
 where
     T: Ord + Borrow<Q>,
     Q: Ord,
@@ -24,8 +26,8 @@ where
 
 impl<T, Q, BH> Set<T, Q> for hashbrown::hash_set::HashSet<T, BH>
 where
-    T: Hash + Eq + Borrow<Q>,
-    Q: Hash + Eq,
+    T: Hash + Eq,
+    Q: ?Sized + Hash + hashbrown::Equivalent<T>,
     BH: BuildHasher,
 {
 }

--- a/frozen-collections-core/src/traits/set_extras.rs
+++ b/frozen-collections-core/src/traits/set_extras.rs
@@ -1,0 +1,40 @@
+use crate::sets::decl_macros::set_extras_trait_funcs;
+use core::hash::{BuildHasher, Hash};
+
+#[cfg(feature = "std")]
+use core::borrow::Borrow;
+
+/// Common query abstractions for sets.
+pub trait SetExtras<T, Q: ?Sized = T> {
+    #[doc = include_str!("../doc_snippets/get_from_set.md")]
+    #[must_use]
+    fn get(&self, value: &Q) -> Option<&T>;
+}
+
+#[cfg(feature = "std")]
+impl<T, Q, BH> SetExtras<T, Q> for std::collections::HashSet<T, BH>
+where
+    T: Eq + Hash + Borrow<Q>,
+    Q: ?Sized + Hash + Eq,
+    BH: BuildHasher,
+{
+    set_extras_trait_funcs!();
+}
+
+#[cfg(feature = "std")]
+impl<T, Q> SetExtras<T, Q> for alloc::collections::BTreeSet<T>
+where
+    T: Ord + Borrow<Q>,
+    Q: Ord,
+{
+    set_extras_trait_funcs!();
+}
+
+impl<T, Q, BH> SetExtras<T, Q> for hashbrown::hash_set::HashSet<T, BH>
+where
+    T: Hash + Eq,
+    Q: ?Sized + Hash + hashbrown::Equivalent<T>,
+    BH: BuildHasher,
+{
+    set_extras_trait_funcs!();
+}

--- a/frozen-collections-core/src/traits/set_iteration.rs
+++ b/frozen-collections-core/src/traits/set_iteration.rs
@@ -1,13 +1,15 @@
+use crate::sets::decl_macros::set_iteration_trait_funcs;
 use core::hash::BuildHasher;
 
 /// Common iteration abstractions for sets.
 pub trait SetIteration<T>: IntoIterator<Item = T> {
+    /// The type of the iterator returned by [`Self::iter`].
     type Iterator<'a>: Iterator<Item = &'a T>
     where
         Self: 'a,
         T: 'a;
 
-    /// An iterator visiting all entries in arbitrary order.
+    #[doc = include_str!("../doc_snippets/iter.md")]
     #[must_use]
     fn iter(&self) -> Self::Iterator<'_>;
 }
@@ -23,23 +25,17 @@ where
         T: 'a,
         BH: 'a;
 
-    #[inline]
-    fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
+    set_iteration_trait_funcs!();
 }
 
 #[cfg(feature = "std")]
-impl<T> SetIteration<T> for std::collections::BTreeSet<T> {
+impl<T> SetIteration<T> for alloc::collections::BTreeSet<T> {
     type Iterator<'a>
         = std::collections::btree_set::Iter<'a, T>
     where
         T: 'a;
 
-    #[inline]
-    fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
+    set_iteration_trait_funcs!();
 }
 
 impl<T, BH> SetIteration<T> for hashbrown::hash_set::HashSet<T, BH>
@@ -52,8 +48,5 @@ where
         T: 'a,
         BH: 'a;
 
-    #[inline]
-    fn iter(&self) -> Self::Iterator<'_> {
-        Self::iter(self)
-    }
+    set_iteration_trait_funcs!();
 }

--- a/frozen-collections-core/src/utils/bitvec.rs
+++ b/frozen-collections-core/src/utils/bitvec.rs
@@ -1,5 +1,6 @@
 //! Simple bit vectors.
 
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 pub struct BitVec {
@@ -8,24 +9,24 @@ pub struct BitVec {
 }
 
 impl BitVec {
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             bits: (0..(capacity as u64).div_ceil(64)).collect(),
             len: capacity,
         }
     }
 
-    pub fn clear_all(&mut self) {
+    pub(crate) fn clear_all(&mut self) {
         self.bits.fill(0);
     }
 
-    pub fn set(&mut self, index: usize) {
+    pub(crate) fn set(&mut self, index: usize) {
         debug_assert!(index < self.len, "Out of bounds");
 
         self.bits[index / 64] |= 1 << (index % 64);
     }
 
-    pub fn get(&self, index: usize) -> bool {
+    pub(crate) fn get(&self, index: usize) -> bool {
         debug_assert!(index < self.len, "Out of bounds");
 
         (self.bits[index / 64] & (1 << (index % 64))) != 0
@@ -56,8 +57,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    #[allow(clippy::should_panic_without_expect)]
+    #[should_panic(expected = "Out of bounds")]
     fn get_panic() {
         let bitvec = BitVec::with_capacity(12);
         _ = bitvec.get(12);

--- a/frozen-collections-core/src/utils/eytzinger.rs
+++ b/frozen-collections-core/src/utils/eytzinger.rs
@@ -6,7 +6,6 @@
 use core::cmp::Ordering;
 
 /// Sorts the slice in-place using the Eytzinger layout.
-#[allow(clippy::module_name_repetitions)]
 pub fn eytzinger_sort<T>(data: &mut [T]) {
     const fn get_eytzinger_index(original_index: usize, slice_len: usize) -> usize {
         let ipk = (original_index + 2).next_power_of_two().trailing_zeros() as usize;
@@ -44,7 +43,6 @@ pub fn eytzinger_sort<T>(data: &mut [T]) {
 ///
 /// The slice must have been previously sorted with the `eytzinger` method.
 #[inline]
-#[allow(clippy::module_name_repetitions)]
 pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
 where
     F: FnMut(&'a T) -> Ordering,
@@ -72,7 +70,7 @@ where
 //const NUM_PREFETCH_LEVELS: usize = 3;
 
 #[inline]
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions, "This is fine")]
 pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
 where
     F: FnMut(&'a T) -> Ordering,

--- a/frozen-collections-macros/src/lib.rs
+++ b/frozen-collections-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "This is an implementation crate, not a public API crate")]
+
 //! Implementation crate for the frozen collections.
 //!
 //! <div class="warning">
@@ -8,9 +10,8 @@
 //! </div>
 
 use frozen_collections_core::macros::{
-    derive_scalar_macro, fz_hash_map_macro, fz_hash_set_macro, fz_ordered_map_macro,
-    fz_ordered_set_macro, fz_scalar_map_macro, fz_scalar_set_macro, fz_string_map_macro,
-    fz_string_set_macro,
+    derive_scalar_macro, fz_hash_map_macro, fz_hash_set_macro, fz_ordered_map_macro, fz_ordered_set_macro, fz_scalar_map_macro,
+    fz_scalar_set_macro, fz_string_map_macro, fz_string_set_macro,
 };
 use proc_macro::TokenStream;
 use proc_macro_error2::proc_macro_error;

--- a/frozen-collections/benches/hashed_keys.rs
+++ b/frozen-collections/benches/hashed_keys.rs
@@ -1,12 +1,9 @@
-extern crate alloc;
+#![expect(missing_docs, reason = "Benchmark")]
 
-use alloc::string::{String, ToString};
-use alloc::vec;
-use alloc::vec::Vec;
 use core::hash::Hash;
 use core::hint::black_box;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use frozen_collections::{FzHashSet, SetQuery, fz_hash_set};
+use frozen_collections::{FzHashSet, fz_hash_set};
 
 include!(concat!(env!("OUT_DIR"), "/hashed.rs"));
 

--- a/frozen-collections/benches/ordered_keys.rs
+++ b/frozen-collections/benches/ordered_keys.rs
@@ -1,6 +1,8 @@
+#![expect(missing_docs, reason = "Benchmark")]
+
 use core::hint::black_box;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use frozen_collections::{FzOrderedSet, SetQuery, fz_ordered_set};
+use frozen_collections::{FzOrderedSet, fz_ordered_set};
 
 include!(concat!(env!("OUT_DIR"), "/ordered.rs"));
 

--- a/frozen-collections/benches/perfect_hashing.rs.keep
+++ b/frozen-collections/benches/perfect_hashing.rs.keep
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Benchmark")]
+
 // NOTE: as of version 0.9.6, the ph crate doesn't compile, so this benchmark is disabled for now
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};

--- a/frozen-collections/benches/scalar_keys.rs
+++ b/frozen-collections/benches/scalar_keys.rs
@@ -1,9 +1,8 @@
-extern crate alloc;
+#![expect(missing_docs, reason = "Benchmark")]
 
-use alloc::vec::Vec;
 use core::hint::black_box;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use frozen_collections::{FzScalarSet, SetQuery, fz_scalar_set};
+use frozen_collections::{FzScalarSet, fz_scalar_set};
 
 include!(concat!(env!("OUT_DIR"), "/dense_scalar.rs"));
 include!(concat!(env!("OUT_DIR"), "/sparse_scalar.rs"));

--- a/frozen-collections/benches/string_keys.rs
+++ b/frozen-collections/benches/string_keys.rs
@@ -1,10 +1,9 @@
-extern crate alloc;
+#![expect(missing_docs, reason = "Benchmark")]
 
-use alloc::vec::Vec;
 use core::hint::black_box;
 use core::ops::Add;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use frozen_collections::{FzStringSet, SetQuery, fz_string_set};
+use frozen_collections::{FzStringSet, fz_string_set};
 
 include!(concat!(env!("OUT_DIR"), "/random_string.rs"));
 include!(concat!(env!("OUT_DIR"), "/prefixed_string.rs"));

--- a/frozen-collections/build.rs
+++ b/frozen-collections/build.rs
@@ -1,3 +1,5 @@
+//! Generates benchmark code.
+
 use rand::Rng;
 use rand_chacha::ChaChaRng;
 use rand_chacha::rand_core::SeedableRng;
@@ -16,11 +18,15 @@ fn emit_benchmark_preamble(name: &str) -> BufWriter<File> {
     let dest_path = Path::new(&out_dir).join(format!("{name}.rs"));
     let mut file = BufWriter::new(File::create(dest_path).unwrap());
 
-    writeln!(file, "#[allow(clippy::unreadable_literal)]").unwrap();
-    writeln!(file, "#[allow(clippy::items_after_statements)]").unwrap();
-    writeln!(file, "#[allow(clippy::explicit_auto_deref)]").unwrap();
-    writeln!(file, "#[allow(clippy::redundant_closure_for_method_calls)]").unwrap();
-    writeln!(file, "#[allow(unused_results)]").unwrap();
+    writeln!(file, "#[allow(clippy::unreadable_literal, reason = \"Generated code\")]").unwrap();
+    writeln!(file, "#[allow(clippy::items_after_statements, reason = \"Generated code\")]").unwrap();
+    writeln!(file, "#[allow(clippy::explicit_auto_deref, reason = \"Generated code\")]").unwrap();
+    writeln!(
+        file,
+        "#[allow(clippy::redundant_closure_for_method_calls, reason = \"Generated code\")]"
+    )
+    .unwrap();
+    writeln!(file, "#[allow(unused_results, reason = \"Generated code\")]").unwrap();
     writeln!(file, "fn {name}(c: &mut Criterion) {{").unwrap();
     writeln!(file, "    let mut group = c.benchmark_group(\"{name}\");").unwrap();
 
@@ -54,11 +60,7 @@ where
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
 
-    writeln!(
-        file,
-        "    let input: Vec<i32> = frozen.clone().into_iter().collect();"
-    )
-    .unwrap();
+    writeln!(file, "    let input: Vec<i32> = frozen.clone().into_iter().collect();").unwrap();
     writeln!(file, "    let size = input.len();").unwrap();
     writeln!(file, "    let mut probe = Vec::new();").unwrap();
     writeln!(file, "    for i in &input {{").unwrap();
@@ -66,7 +68,11 @@ where
     writeln!(file, "        probe.push(-(*i));").unwrap();
     writeln!(file, "    }}").unwrap();
 
-    writeln!(file, "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());").unwrap();
+    writeln!(
+        file,
+        "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());"
+    )
+    .unwrap();
     emit_loop(file, "HashSet(classic)");
 
     writeln!(
@@ -115,7 +121,11 @@ where
     writeln!(file, "    }}").unwrap();
     writeln!(file, "    let probe = tmp;").unwrap();
 
-    writeln!(file, "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());").unwrap();
+    writeln!(
+        file,
+        "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());"
+    )
+    .unwrap();
     emit_loop(file, "HashSet(classic)");
 
     writeln!(
@@ -140,27 +150,19 @@ where
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
 
-    writeln!(
-        file,
-        "    let input: Vec<_> = frozen.clone().into_iter().collect();"
-    )
-    .unwrap();
+    writeln!(file, "    let input: Vec<_> = frozen.clone().into_iter().collect();").unwrap();
     writeln!(file, "    let size = input.len();").unwrap();
     writeln!(file, "    let mut probe = Vec::new();").unwrap();
     writeln!(file, "    for i in &input {{").unwrap();
-    writeln!(
-        file,
-        "        probe.push(Record {{ name: (*i).name.clone(), age: (*i).age }});"
-    )
-    .unwrap();
-    writeln!(
-        file,
-        "        probe.push(Record {{ name: (*i).name.clone(), age: -(*i).age }});"
-    )
-    .unwrap();
+    writeln!(file, "        probe.push(Record {{ name: (*i).name.clone(), age: (*i).age }});").unwrap();
+    writeln!(file, "        probe.push(Record {{ name: (*i).name.clone(), age: -(*i).age }});").unwrap();
     writeln!(file, "    }}").unwrap();
 
-    writeln!(file, "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());").unwrap();
+    writeln!(
+        file,
+        "    let s = std::collections::HashSet::<_, std::hash::RandomState>::from_iter(input.clone());"
+    )
+    .unwrap();
     emit_loop(file, "HashSet(classic)");
 
     writeln!(
@@ -185,31 +187,15 @@ where
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
 
-    writeln!(
-        file,
-        "    let input: Vec<_> = frozen.clone().into_iter().collect();"
-    )
-    .unwrap();
+    writeln!(file, "    let input: Vec<_> = frozen.clone().into_iter().collect();").unwrap();
     writeln!(file, "    let size = input.len();").unwrap();
     writeln!(file, "    let mut probe = Vec::new();").unwrap();
     writeln!(file, "    for i in &input {{").unwrap();
-    writeln!(
-        file,
-        "        probe.push(Record {{ name: (*i).name.clone(), age: (*i).age }});"
-    )
-    .unwrap();
-    writeln!(
-        file,
-        "        probe.push(Record {{ name: (*i).name.clone(), age: -(*i).age }});"
-    )
-    .unwrap();
+    writeln!(file, "        probe.push(Record {{ name: (*i).name.clone(), age: (*i).age }});").unwrap();
+    writeln!(file, "        probe.push(Record {{ name: (*i).name.clone(), age: -(*i).age }});").unwrap();
     writeln!(file, "    }}").unwrap();
 
-    writeln!(
-        file,
-        "    let s = std::collections::BTreeSet::<_>::from_iter(input.clone());"
-    )
-    .unwrap();
+    writeln!(file, "    let s = std::collections::BTreeSet::<_>::from_iter(input.clone());").unwrap();
     emit_loop(file, "BTreeSet");
 
     writeln!(file, "    let s = FzOrderedSet::new(input);").unwrap();
@@ -345,11 +331,7 @@ fn emit_hashed_benchmark() {
             }
 
             let age: i32 = rng.random();
-            writeln!(
-                file,
-                "        Record {{ name: \"{s}\".to_string(), age: {age} }},"
-            )
-            .unwrap();
+            writeln!(file, "        Record {{ name: \"{s}\".to_string(), age: {age} }},").unwrap();
         }
     }
 
@@ -384,21 +366,13 @@ fn emit_ordered_benchmark() {
             }
 
             let age: i32 = rng.random();
-            writeln!(
-                file,
-                "        Record {{ name: \"{s}\".to_string(), age: {age} }},"
-            )
-            .unwrap();
+            writeln!(file, "        Record {{ name: \"{s}\".to_string(), age: {age} }},").unwrap();
         }
     }
 
     let mut file = emit_benchmark_preamble("ordered");
 
-    writeln!(
-        file,
-        "#[derive(Clone, Debug, Eq, Ord, PartialOrd, PartialEq)]"
-    )
-    .unwrap();
+    writeln!(file, "#[derive(Clone, Debug, Eq, Ord, PartialOrd, PartialEq)]").unwrap();
     writeln!(file, "struct Record {{").unwrap();
     writeln!(file, "    name: String,").unwrap();
     writeln!(file, "    age: i32,").unwrap();

--- a/frozen-collections/src/lib.rs
+++ b/frozen-collections/src/lib.rs
@@ -160,18 +160,18 @@
 //!
 //! The maps produced by this crate implement the following traits:
 //!
-//! - [`Map`]. The primary representation of a map. This trait has [`MapQuery`] and
-//!   [`MapIteration`] as super-traits.
-//! - [`MapQuery`]. A trait for querying maps. This is an object-safe trait.
-//! - [`MapIteration`]. A trait for iterating over maps.
+//! - [`Map`]. The primary representation of a map.
+//! - [`MapQuery`]. A dyn compatible trait for querying maps.
+//! - [`MapIteration`]. A dyn compatible trait for iterating over maps.
+//! - [`MapExtras`]. A trait for extra map operations.
 //!
 //! The sets produced by this crate implement the following traits:
 //!
-//! - [`Set`]. The primary representation of a set. This trait has [`SetQuery`],
-//!   [`SetIteration`] and [`SetOps`] as super-traits.
-//! - [`SetQuery`]. A trait for querying sets. This is an object-safe trait.
-//! - [`SetIteration`]. A trait for iterating over sets.
+//! - [`Set`]. The primary representation of a set.
+//! - [`SetQuery`]. A dyn compatible trait for querying sets.
+//! - [`SetIteration`]. A dyn compatible trait for iterating over sets.
 //! - [`SetOps`]. A trait for set operations like union and intersections.
+//! - [`SetExtras`]. A trait for extra set operations.
 //!
 //! # Performance Considerations
 //!
@@ -240,16 +240,10 @@
 //!
 //! All features are enabled by default.
 
-extern crate alloc;
-
-pub use frozen_collections_core::traits::{
-    Map, MapIteration, MapQuery, Scalar, Set, SetIteration, SetOps, SetQuery,
-};
+pub use frozen_collections_core::traits::{Map, MapExtras, MapIteration, MapQuery, Scalar, Set, SetExtras, SetIteration, SetOps, SetQuery};
 
 #[doc(hidden)]
-pub use frozen_collections_core::traits::{
-    CollectionMagnitude, Hasher, LargeCollection, Len, MediumCollection, SmallCollection,
-};
+pub use frozen_collections_core::traits::{CollectionMagnitude, Hasher, LargeCollection, Len, MediumCollection, SmallCollection};
 
 /// Creates an efficient map with a fixed set of hashable keys.
 ///

--- a/frozen-collections/tests/common/set_testing.rs
+++ b/frozen-collections/tests/common/set_testing.rs
@@ -70,13 +70,11 @@ where
     assert!(!s.contains(&T::default()));
     assert_eq!(0, s.len());
     assert!(s.is_empty());
+    assert!(s.get(&T::default()).is_none());
 }
 
-pub fn test_set_ops<'a, ST, T>(
-    set: &'a ST,
-    reference: &'a HashbrownSet<T>,
-    other: &'a HashbrownSet<T>,
-) where
+pub fn test_set_ops<'a, ST, T>(set: &'a ST, reference: &'a HashbrownSet<T>, other: &'a HashbrownSet<T>)
+where
     T: 'a + Hash + Eq + Clone + Debug,
     ST: 'a + Set<T> + Debug + Clone + PartialEq<HashbrownSet<T>>,
     &'a ST: BitOr<&'a HashbrownSet<T>, Output = HashbrownSet<T>>

--- a/frozen-collections/tests/derive_scalar_macro_tests.rs
+++ b/frozen-collections/tests/derive_scalar_macro_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 use frozen_collections::*;
 use frozen_collections_core::macros::derive_scalar_macro;
 use quote::quote;

--- a/frozen-collections/tests/hash_macro_tests.rs
+++ b/frozen-collections/tests/hash_macro_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 use frozen_collections::*;
 use frozen_collections_core::macros::{fz_hash_map_macro, fz_hash_set_macro};
 use hashbrown::HashMap as HashbrownMap;
@@ -123,11 +125,7 @@ macro_rules! test_hash {
 #[test]
 fn hash_complex() {
     test_hash!(Person, Person { name: "A", age: 1 },);
-    test_hash!(
-        Person,
-        Person { name: "A", age: 1 },
-        Person { name: "B", age: 2 },
-    );
+    test_hash!(Person, Person { name: "A", age: 1 }, Person { name: "B", age: 2 },);
     test_hash!(
         Person,
         Person { name: "A", age: 1 },
@@ -262,185 +260,185 @@ fn hash_complex() {
 
 #[test]
 fn hash_i8() {
-    test_hash!(i8, 0i8);
-    test_hash!(i8, 0i8, 1,);
-    test_hash!(i8, 0i8, 1, 2,);
-    test_hash!(i8, 0i8, 1, 2, 3,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(i8, 0_i8);
+    test_hash!(i8, 0_i8, 1,);
+    test_hash!(i8, 0_i8, 1, 2,);
+    test_hash!(i8, 0_i8, 1, 2, 3,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 
     // test duplicate logic
-    test_hash!(i8, 0i8, 1, 2, 1, 1);
+    test_hash!(i8, 0_i8, 1, 2, 1, 1);
 }
 
 #[test]
 fn hash_u8() {
-    test_hash!(u8, 0u8);
-    test_hash!(u8, 0u8, 1,);
-    test_hash!(u8, 0u8, 1, 2,);
-    test_hash!(u8, 0u8, 1, 2, 3,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(u8, 0_u8);
+    test_hash!(u8, 0_u8, 1,);
+    test_hash!(u8, 0_u8, 1, 2,);
+    test_hash!(u8, 0_u8, 1, 2, 3,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_i16() {
-    test_hash!(i16, 0i16);
-    test_hash!(i16, 0i16, 1,);
-    test_hash!(i16, 0i16, 1, 2,);
-    test_hash!(i16, 0i16, 1, 2, 3,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(i16, 0_i16);
+    test_hash!(i16, 0_i16, 1,);
+    test_hash!(i16, 0_i16, 1, 2,);
+    test_hash!(i16, 0_i16, 1, 2, 3,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_u16() {
-    test_hash!(u16, 0u16);
-    test_hash!(u16, 0u16, 1,);
-    test_hash!(u16, 0u16, 1, 2,);
-    test_hash!(u16, 0u16, 1, 2, 3,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(u16, 0_u16);
+    test_hash!(u16, 0_u16, 1,);
+    test_hash!(u16, 0_u16, 1, 2,);
+    test_hash!(u16, 0_u16, 1, 2, 3,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_i32() {
-    test_hash!(i32, 0i32);
-    test_hash!(i32, 0i32, 1,);
-    test_hash!(i32, 0i32, 1, 2,);
-    test_hash!(i32, 0i32, 1, 2, 3,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(i32, 0_i32);
+    test_hash!(i32, 0_i32, 1,);
+    test_hash!(i32, 0_i32, 1, 2,);
+    test_hash!(i32, 0_i32, 1, 2, 3,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_u32() {
-    test_hash!(u32, 0u32);
-    test_hash!(u32, 0u32, 1,);
-    test_hash!(u32, 0u32, 1, 2,);
-    test_hash!(u32, 0u32, 1, 2, 3,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(u32, 0_u32);
+    test_hash!(u32, 0_u32, 1,);
+    test_hash!(u32, 0_u32, 1, 2,);
+    test_hash!(u32, 0_u32, 1, 2, 3,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_i64() {
-    test_hash!(i64, 0i64);
-    test_hash!(i64, 0i64, 1,);
-    test_hash!(i64, 0i64, 1, 2,);
-    test_hash!(i64, 0i64, 1, 2, 3,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(i64, 0_i64);
+    test_hash!(i64, 0_i64, 1,);
+    test_hash!(i64, 0_i64, 1, 2,);
+    test_hash!(i64, 0_i64, 1, 2, 3,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_u64() {
-    test_hash!(u64, 0u64);
-    test_hash!(u64, 0u64, 1,);
-    test_hash!(u64, 0u64, 1, 2,);
-    test_hash!(u64, 0u64, 1, 2, 3,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(u64, 0_u64);
+    test_hash!(u64, 0_u64, 1,);
+    test_hash!(u64, 0_u64, 1, 2,);
+    test_hash!(u64, 0_u64, 1, 2, 3,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_isize() {
-    test_hash!(isize, 0isize);
-    test_hash!(isize, 0isize, 1,);
-    test_hash!(isize, 0isize, 1, 2,);
-    test_hash!(isize, 0isize, 1, 2, 3,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(isize, 0_isize);
+    test_hash!(isize, 0_isize, 1,);
+    test_hash!(isize, 0_isize, 1, 2,);
+    test_hash!(isize, 0_isize, 1, 2, 3,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn hash_usize() {
-    test_hash!(usize, 0usize);
-    test_hash!(usize, 0usize, 1,);
-    test_hash!(usize, 0usize, 1, 2,);
-    test_hash!(usize, 0usize, 1, 2, 3,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_hash!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_hash!(usize, 0_usize);
+    test_hash!(usize, 0_usize, 1,);
+    test_hash!(usize, 0_usize, 1, 2,);
+    test_hash!(usize, 0_usize, 1, 2, 3,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_hash!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
@@ -454,64 +452,10 @@ fn hash_string() {
     test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6");
     test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7");
     test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8");
-    test_hash!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9"
-    );
-    test_hash!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10"
-    );
-    test_hash!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11"
-    );
-    test_hash!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12"
-    );
+    test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11");
+    test_hash!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12");
     test_hash!(
         &'static str,
         "0",

--- a/frozen-collections/tests/omni_tests.rs
+++ b/frozen-collections/tests/omni_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 mod common;
 
 use common::*;
@@ -318,12 +320,12 @@ macro_rules! test_all {
 
         // handle &str cases
 
-        let set_reference = HashbrownSet::<&str>::from_iter(vec![ $( stringify!($input), )* ].into_iter());
-        let set_other = HashbrownSet::<&str>::from_iter(vec![ $( stringify!($other), )* ].into_iter());
+        let set_reference = HashbrownSet::from_iter(vec![ $( stringify!($input).to_string().into_boxed_str(), )* ].into_iter());
+        let set_other = HashbrownSet::from_iter(vec![ $( stringify!($other).to_string().into_boxed_str(), )* ].into_iter());
         let set_input = vec![ $( stringify!($input), )* ];
 
-        let map_reference = HashbrownMap::<_, _>::from_iter(vec![ $( (stringify!($input), ()), )* ].into_iter());
-        let map_other = HashbrownMap::<_, _>::from_iter(vec![ $( (stringify!($other), ()), )* ].into_iter());
+        let map_reference = HashbrownMap::from_iter(vec![ $( (stringify!($input).to_string().into_boxed_str(), ()), )* ].into_iter());
+        let map_other = HashbrownMap::from_iter(vec![ $( (stringify!($other).to_string().into_boxed_str(), ()), )* ].into_iter());
         let map_input = vec![ $( (stringify!($input), ()), )* ];
 
         let mut m = FzStringMap::new(map_input.clone());
@@ -352,49 +354,10 @@ macro_rules! test_all {
         test_set(&s, &set_reference, &set_other);
         test_set_ops(&s, &set_reference, &set_other);
         test_set_iter(&s, &set_reference);
-
-        // handle String cases
-
-        let set_reference = HashbrownSet::<String>::from_iter(vec![ $( stringify!($input).to_string(), )* ].into_iter());
-        let set_other = HashbrownSet::<String>::from_iter(vec![ $( stringify!($other).to_string(), )* ].into_iter());
-        let set_input = vec![ $( stringify!($input).to_string(), )* ];
-
-        let map_reference = HashbrownMap::<_, _>::from_iter(vec![ $( (stringify!($input).to_string(), ()), )* ].into_iter());
-        let map_other = HashbrownMap::<_, _>::from_iter(vec![ $( (stringify!($other).to_string(), ()), )* ].into_iter());
-        let map_input = vec![ $( (stringify!($input).to_string(), ()), )* ];
-
-        let mut m = FzStringMap::new_with_strings(map_input.clone());
-        test_map(&m, &map_reference, &map_other);
-        test_map_ops(&m, &map_reference);
-        test_map_iter(&m, &map_reference);
-        test_map_iter_mut(&mut m, &map_reference);
-
-        let mut m = FzStringMap::from_iter(map_input.clone().into_iter());
-        test_map(&m, &map_reference, &map_other);
-        test_map_ops(&m, &map_reference);
-        test_map_iter(&m, &map_reference);
-        test_map_iter_mut(&mut m, &map_reference);
-
-        let s = FzStringSet::from(m);
-        test_set(&s, &set_reference, &set_other);
-        test_set_ops(&s, &set_reference, &set_other);
-        test_set_iter(&s, &set_reference);
-
-        let s = FzStringSet::new_with_strings(set_input.clone());
-        test_set(&s, &set_reference, &set_other);
-        test_set_ops(&s, &set_reference, &set_other);
-        test_set_iter(&s, &set_reference);
-
-        let s = FzStringSet::from_iter(set_input.clone().into_iter());
-        test_set(&s, &set_reference, &set_other);
-        test_set_ops(&s, &set_reference, &set_other);
-        test_set_iter(&s, &set_reference);
     }
 }
 
 #[test]
-#[allow(clippy::unreadable_literal)]
-#[allow(clippy::large_stack_frames)]
 fn test_common() {
     let m = EytzingerSearchMap::new(vec![(1, 2)]);
     test_map_serialization::<_, _, _, FzOrderedMap<_, _>>(&m);
@@ -420,7 +383,7 @@ fn test_common() {
     test_all!(1, 2, 3, 4, 5, 6, 7, 8, 9 ; 3, 10);
     test_all!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ; 3);
     test_all!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ; 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 20);
-    test_all!(11111, 11112, 11114, 11115, 111165, 111175 ; 2500, 333333333);
+    test_all!(11_111, 11_112, 11_114, 11_115, 111_165, 111_175 ; 2500, 333_333_333);
 
     // trigger the eytzinger facade code
     test_all!(
@@ -430,7 +393,7 @@ fn test_common() {
         330, 331, 332, 333, 334, 335, 336, 337, 338, 339,
         440, 441, 442, 443, 444, 445, 446, 447, 448, 449,
         550, 551, 552, 553, 554, 555, 556, 557, 558, 559,
-        660, 661, 662, 663, 664, 665, 666, 667, 668, 669; 2500, 333333333);
+        660, 661, 662, 663, 664, 665, 666, 667, 668, 669; 2500, 333_333_333);
 
     test_str!("1", "2", "3" ; "3", "4", "5");
     test_str!("0", "1" ; "0", "1");
@@ -469,8 +432,8 @@ fn test_set_defaults() {
     test_set_default::<FzHashSet<i32>, i32>();
     test_set_default::<FzOrderedSet<i32>, i32>();
     test_set_default::<FzScalarSet<i32>, i32>();
-    test_set_default::<FzStringSet<&str>, &str>();
-    test_set_default::<FzStringSet<String>, String>();
+
+    test_set_default::<FzStringSet<Box<str>>, Box<str>>();
 }
 
 #[test]
@@ -484,8 +447,7 @@ fn test_map_defaults() {
     test_map_default::<FzHashMap<i32, i32>, i32>();
     test_map_default::<FzOrderedMap<i32, i32>, i32>();
     test_map_default::<FzScalarMap<i32, i32>, i32>();
-    test_map_default::<FzStringMap<&str, i32>, &str>();
-    test_map_default::<FzStringMap<String, i32>, String>();
+    test_map_default::<FzStringMap<Box<str>, i32>, Box<str>>();
 }
 
 #[test]
@@ -500,9 +462,7 @@ fn test_set_empties() {
     test_set_empty(&hashbrown::HashSet::<i32>::from_iter(vec![]));
 
     test_set_empty(&EytzingerSearchSet::<i32>::default());
-    test_set_empty(&EytzingerSearchSet::<i32>::new(EytzingerSearchMap::new(
-        vec![],
-    )));
+    test_set_empty(&EytzingerSearchSet::<i32>::new(EytzingerSearchMap::new(vec![])));
 
     test_set_empty(&BinarySearchSet::<i32>::default());
     test_set_empty(&BinarySearchSet::<i32>::new(BinarySearchMap::new(vec![])));
@@ -511,19 +471,13 @@ fn test_set_empties() {
     test_set_empty(&ScanSet::<i32>::new(ScanMap::new(vec![])));
 
     test_set_empty(&DenseScalarLookupSet::<i32>::default());
-    test_set_empty(&DenseScalarLookupSet::<i32>::new(
-        DenseScalarLookupMap::new(vec![]).unwrap(),
-    ));
+    test_set_empty(&DenseScalarLookupSet::<i32>::new(DenseScalarLookupMap::new(vec![]).unwrap()));
 
     test_set_empty(&SparseScalarLookupSet::<i32>::default());
-    test_set_empty(&SparseScalarLookupSet::<i32>::new(
-        SparseScalarLookupMap::new(vec![]),
-    ));
+    test_set_empty(&SparseScalarLookupSet::<i32>::new(SparseScalarLookupMap::new(vec![])));
 
     test_set_empty(&HashSet::<i32>::default());
-    test_set_empty(&HashSet::<i32>::new(
-        HashMap::with_hasher(vec![], BridgeHasher::default()).unwrap(),
-    ));
+    test_set_empty(&HashSet::<i32>::new(HashMap::with_hasher(vec![], BridgeHasher::default()).unwrap()));
 
     test_set_empty(&FzHashSet::<i32>::default());
     test_set_empty(&FzHashSet::<i32>::from(FzHashMap::new(vec![])));
@@ -534,11 +488,13 @@ fn test_set_empties() {
     test_set_empty(&FzScalarSet::<i32>::default());
     test_set_empty(&FzScalarSet::<i32>::from(FzScalarMap::new(vec![])));
 
-    test_set_empty(&FzStringSet::<&str>::default());
-    test_set_empty(&FzStringSet::from(FzStringMap::new(vec![])));
+    let v: Vec<(&str, ())> = Vec::new();
+    test_set_empty(&FzStringSet::<Box<str>>::default());
+    test_set_empty(&FzStringSet::from(FzStringMap::new(v)));
 
-    test_set_empty(&FzStringSet::<String>::default());
-    test_set_empty(&FzStringSet::from(FzStringMap::new_with_strings(vec![])));
+    let v: Vec<(&str, ())> = Vec::new();
+    test_set_empty(&FzStringSet::<Box<str>>::default());
+    test_set_empty(&FzStringSet::from(FzStringMap::new(v)));
 }
 
 #[test]
@@ -579,11 +535,13 @@ fn test_map_empties() {
     test_map_empty(&FzScalarMap::<i32, i32>::default());
     test_map_empty(&FzScalarMap::<i32, i32>::new(vec![]));
 
-    test_map_empty(&FzStringMap::<&str, i32>::default());
-    test_map_empty(&FzStringMap::<&str, i32>::new(vec![]));
+    let v: Vec<(&str, i32)> = Vec::new();
+    test_map_empty(&FzStringMap::<Box<str>, i32>::default());
+    test_map_empty(&FzStringMap::<Box<str>, i32>::new(v));
 
-    test_map_empty(&FzStringMap::<String, i32>::default());
-    test_map_empty(&FzStringMap::<String, i32>::new_with_strings(vec![]));
+    let v: Vec<(&str, i32)> = Vec::new();
+    test_map_empty(&FzStringMap::<Box<str>, i32>::default());
+    test_map_empty(&FzStringMap::<Box<str>, i32>::new(v));
 
     fz_hash_map!(let m: MyHashMap<i32, i32>, {});
     test_map_empty(&m);
@@ -633,18 +591,18 @@ fn edge_cases() {
 fn str_type_serialization() {
     let m1 = FzStringMap::<_, _>::from([("A", 1), ("B", 2)]);
     let json = serde_json::to_string(&m1).unwrap();
-    let m2: FzStringMap<&str, i32> = serde_json::from_str(&json).unwrap();
+    let m2: FzStringMap<Box<str>, i32> = serde_json::from_str(&json).unwrap();
     assert_eq_map(&m1, &m2);
 
     let s1 = FzStringSet::<_>::from(["A", "B"]);
     let json = serde_json::to_string(&s1).unwrap();
-    let s2: FzStringSet<&str> = serde_json::from_str(&json).unwrap();
+    let s2: FzStringSet<Box<str>> = serde_json::from_str(&json).unwrap();
     assert_eq_set(&s1, &s2);
 
-    let m: serde_json::Result<FzStringMap<&str, i32>> = serde_json::from_str("[\"123\": 2]");
+    let m: serde_json::Result<FzStringMap<Box<str>, i32>> = serde_json::from_str("[\"123\": 2]");
     assert!(m.is_err());
 
-    let s: serde_json::Result<FzStringSet<&str>> = serde_json::from_str("{XXX: XXX,}");
+    let s: serde_json::Result<FzStringSet<Box<str>>> = serde_json::from_str("{XXX: XXX,}");
     assert!(s.is_err());
 }
 
@@ -652,18 +610,18 @@ fn str_type_serialization() {
 fn string_type_serialization() {
     let m1 = FzStringMap::<_, _>::from([("A".to_string(), 1), ("B".to_string(), 2)]);
     let json = serde_json::to_string(&m1).unwrap();
-    let m2: FzStringMap<String, i32> = serde_json::from_str(&json).unwrap();
+    let m2: FzStringMap<Box<str>, i32> = serde_json::from_str(&json).unwrap();
     assert_eq_map(&m1, &m2);
 
     let s1 = FzStringSet::<_>::from(["A".to_string(), "B".to_string()]);
     let json = serde_json::to_string(&s1).unwrap();
-    let s2: FzStringSet<String> = serde_json::from_str(&json).unwrap();
+    let s2: FzStringSet<Box<str>> = serde_json::from_str(&json).unwrap();
     assert_eq_set(&s1, &s2);
 
-    let m: serde_json::Result<FzStringMap<String, i32>> = serde_json::from_str("[\"123\": 2]");
+    let m: serde_json::Result<FzStringMap<Box<str>, i32>> = serde_json::from_str("[\"123\": 2]");
     assert!(m.is_err());
 
-    let s: serde_json::Result<FzStringSet<String>> = serde_json::from_str("{XXX: XXX,}");
+    let s: serde_json::Result<FzStringSet<Box<str>>> = serde_json::from_str("{XXX: XXX,}");
     assert!(s.is_err());
 }
 

--- a/frozen-collections/tests/ordered_macro_tests.rs
+++ b/frozen-collections/tests/ordered_macro_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 use frozen_collections::*;
 use frozen_collections_core::macros::{fz_ordered_map_macro, fz_ordered_set_macro};
 use quote::quote;
@@ -123,11 +125,7 @@ macro_rules! test_ordered {
 #[test]
 fn ordered_complex() {
     test_ordered!(Person, Person { name: "A", age: 1 },);
-    test_ordered!(
-        Person,
-        Person { name: "A", age: 1 },
-        Person { name: "B", age: 2 },
-    );
+    test_ordered!(Person, Person { name: "A", age: 1 }, Person { name: "B", age: 2 },);
     test_ordered!(
         Person,
         Person { name: "A", age: 1 },
@@ -274,22 +272,10 @@ fn ordered_complex() {
         Person { name: "xG", age: 7 },
         Person { name: "xH", age: 8 },
         Person { name: "xI", age: 9 },
-        Person {
-            name: "xJ",
-            age: 10
-        },
-        Person {
-            name: "xK",
-            age: 11
-        },
-        Person {
-            name: "xL",
-            age: 12
-        },
-        Person {
-            name: "xM",
-            age: 13
-        },
+        Person { name: "xJ", age: 10 },
+        Person { name: "xK", age: 11 },
+        Person { name: "xL", age: 12 },
+        Person { name: "xM", age: 13 },
         Person { name: "aA", age: 1 },
         Person { name: "aB", age: 2 },
         Person { name: "aC", age: 3 },
@@ -299,22 +285,10 @@ fn ordered_complex() {
         Person { name: "aG", age: 7 },
         Person { name: "aH", age: 8 },
         Person { name: "aI", age: 9 },
-        Person {
-            name: "aJ",
-            age: 10
-        },
-        Person {
-            name: "aK",
-            age: 11
-        },
-        Person {
-            name: "aL",
-            age: 12
-        },
-        Person {
-            name: "aM",
-            age: 13
-        },
+        Person { name: "aJ", age: 10 },
+        Person { name: "aK", age: 11 },
+        Person { name: "aL", age: 12 },
+        Person { name: "aM", age: 13 },
         Person { name: "zA", age: 1 },
         Person { name: "zB", age: 2 },
         Person { name: "zC", age: 3 },
@@ -324,22 +298,10 @@ fn ordered_complex() {
         Person { name: "zG", age: 7 },
         Person { name: "zH", age: 8 },
         Person { name: "zI", age: 9 },
-        Person {
-            name: "zJ",
-            age: 10
-        },
-        Person {
-            name: "zK",
-            age: 11
-        },
-        Person {
-            name: "zL",
-            age: 12
-        },
-        Person {
-            name: "zM",
-            age: 13
-        },
+        Person { name: "zJ", age: 10 },
+        Person { name: "zK", age: 11 },
+        Person { name: "zL", age: 12 },
+        Person { name: "zM", age: 13 },
         Person { name: "vA", age: 1 },
         Person { name: "vB", age: 2 },
         Person { name: "vC", age: 3 },
@@ -349,22 +311,10 @@ fn ordered_complex() {
         Person { name: "vG", age: 7 },
         Person { name: "vH", age: 8 },
         Person { name: "vI", age: 9 },
-        Person {
-            name: "vJ",
-            age: 10
-        },
-        Person {
-            name: "vK",
-            age: 11
-        },
-        Person {
-            name: "vL",
-            age: 12
-        },
-        Person {
-            name: "vM",
-            age: 13
-        },
+        Person { name: "vJ", age: 10 },
+        Person { name: "vK", age: 11 },
+        Person { name: "vL", age: 12 },
+        Person { name: "vM", age: 13 },
     );
 
     // test duplicate logic
@@ -379,160 +329,158 @@ fn ordered_complex() {
 
 #[test]
 fn ordered_i8() {
-    test_ordered!(i8, 0i8);
-    test_ordered!(i8, 0i8, 1,);
-    test_ordered!(i8, 0i8, 1, 2,);
-    test_ordered!(i8, 0i8, 1, 2, 3,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(i8, 0_i8);
+    test_ordered!(i8, 0_i8, 1,);
+    test_ordered!(i8, 0_i8, 1, 2,);
+    test_ordered!(i8, 0_i8, 1, 2, 3,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 
     test_ordered!(
-        i8, 0i8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-        23, 24, 25, 26, 27, 28, 29,
+        i8, 0_i8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
     );
 
     test_ordered!(
-        i8, 0i8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-        23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-        46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+        i8, 0_i8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
     );
 
     // test duplicate logic
-    test_ordered!(i8, 0i8, 1, 2, 1, 1);
+    test_ordered!(i8, 0_i8, 1, 2, 1, 1);
 }
 
 #[test]
 fn ordered_u8() {
-    test_ordered!(u8, 0u8);
-    test_ordered!(u8, 0u8, 1,);
-    test_ordered!(u8, 0u8, 1, 2,);
-    test_ordered!(u8, 0u8, 1, 2, 3,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(u8, 0_u8);
+    test_ordered!(u8, 0_u8, 1,);
+    test_ordered!(u8, 0_u8, 1, 2,);
+    test_ordered!(u8, 0_u8, 1, 2, 3,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_i16() {
-    test_ordered!(i16, 0i16);
-    test_ordered!(i16, 0i16, 1,);
-    test_ordered!(i16, 0i16, 1, 2,);
-    test_ordered!(i16, 0i16, 1, 2, 3,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(i16, 0_i16);
+    test_ordered!(i16, 0_i16, 1,);
+    test_ordered!(i16, 0_i16, 1, 2,);
+    test_ordered!(i16, 0_i16, 1, 2, 3,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_u16() {
-    test_ordered!(u16, 0u16);
-    test_ordered!(u16, 0u16, 1,);
-    test_ordered!(u16, 0u16, 1, 2,);
-    test_ordered!(u16, 0u16, 1, 2, 3,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(u16, 0_u16);
+    test_ordered!(u16, 0_u16, 1,);
+    test_ordered!(u16, 0_u16, 1, 2,);
+    test_ordered!(u16, 0_u16, 1, 2, 3,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_i32() {
-    test_ordered!(i32, 0i32);
-    test_ordered!(i32, 0i32, 1,);
-    test_ordered!(i32, 0i32, 1, 2,);
-    test_ordered!(i32, 0i32, 1, 2, 3,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(i32, 0_i32);
+    test_ordered!(i32, 0_i32, 1,);
+    test_ordered!(i32, 0_i32, 1, 2,);
+    test_ordered!(i32, 0_i32, 1, 2, 3,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_u32() {
-    test_ordered!(u32, 0u32);
-    test_ordered!(u32, 0u32, 1,);
-    test_ordered!(u32, 0u32, 1, 2,);
-    test_ordered!(u32, 0u32, 1, 2, 3,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(u32, 0_u32);
+    test_ordered!(u32, 0_u32, 1,);
+    test_ordered!(u32, 0_u32, 1, 2,);
+    test_ordered!(u32, 0_u32, 1, 2, 3,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_i64() {
-    test_ordered!(i64, 0i64);
-    test_ordered!(i64, 0i64, 1,);
-    test_ordered!(i64, 0i64, 1, 2,);
-    test_ordered!(i64, 0i64, 1, 2, 3,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(i64, 0_i64);
+    test_ordered!(i64, 0_i64, 1,);
+    test_ordered!(i64, 0_i64, 1, 2,);
+    test_ordered!(i64, 0_i64, 1, 2, 3,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn ordered_u64() {
-    test_ordered!(u64, 0u64);
-    test_ordered!(u64, 0u64, 1,);
-    test_ordered!(u64, 0u64, 1, 2,);
-    test_ordered!(u64, 0u64, 1, 2, 3,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_ordered!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_ordered!(u64, 0_u64);
+    test_ordered!(u64, 0_u64, 1,);
+    test_ordered!(u64, 0_u64, 1, 2,);
+    test_ordered!(u64, 0_u64, 1, 2, 3,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_ordered!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
@@ -546,64 +494,10 @@ fn ordered_string() {
     test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6");
     test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7");
     test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8");
-    test_ordered!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9"
-    );
-    test_ordered!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10"
-    );
-    test_ordered!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11"
-    );
-    test_ordered!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12"
-    );
+    test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11");
+    test_ordered!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12");
     test_ordered!(
         &'static str,
         "0",

--- a/frozen-collections/tests/scalar_macro_tests.rs
+++ b/frozen-collections/tests/scalar_macro_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 use frozen_collections::*;
 use frozen_collections_core::macros::{fz_scalar_map_macro, fz_scalar_set_macro};
 use quote::quote;
@@ -116,210 +118,210 @@ macro_rules! test_scalar {
 
 #[test]
 fn scalar_i8() {
-    test_scalar!(i8, 0i8);
-    test_scalar!(i8, 0i8, 1,);
-    test_scalar!(i8, 0i8, 1, 2,);
-    test_scalar!(i8, 0i8, 1, 2, 3,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(i8, 0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(i8, 0_i8);
+    test_scalar!(i8, 0_i8, 1,);
+    test_scalar!(i8, 0_i8, 1, 2,);
+    test_scalar!(i8, 0_i8, 1, 2, 3,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(i8, 0_i8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 
     // test duplicate logic
-    test_scalar!(i8, 0i8, 1, 2, 1, 1);
+    test_scalar!(i8, 0_i8, 1, 2, 1, 1);
 }
 
 #[test]
 fn scalar_u8() {
-    test_scalar!(u8, 0u8);
-    test_scalar!(u8, 0u8, 1,);
-    test_scalar!(u8, 0u8, 1, 2,);
-    test_scalar!(u8, 0u8, 1, 2, 3,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(u8, 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(u8, 0_u8);
+    test_scalar!(u8, 0_u8, 1,);
+    test_scalar!(u8, 0_u8, 1, 2,);
+    test_scalar!(u8, 0_u8, 1, 2, 3,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(u8, 0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_i16() {
-    test_scalar!(i16, 0i16);
-    test_scalar!(i16, 0i16, 1,);
-    test_scalar!(i16, 0i16, 1, 2,);
-    test_scalar!(i16, 0i16, 1, 2, 3,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(i16, 0i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(i16, 0_i16);
+    test_scalar!(i16, 0_i16, 1,);
+    test_scalar!(i16, 0_i16, 1, 2,);
+    test_scalar!(i16, 0_i16, 1, 2, 3,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(i16, 0_i16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_u16() {
-    test_scalar!(u16, 0u16);
-    test_scalar!(u16, 0u16, 1,);
-    test_scalar!(u16, 0u16, 1, 2,);
-    test_scalar!(u16, 0u16, 1, 2, 3,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(u16, 0u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(u16, 0_u16);
+    test_scalar!(u16, 0_u16, 1,);
+    test_scalar!(u16, 0_u16, 1, 2,);
+    test_scalar!(u16, 0_u16, 1, 2, 3,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(u16, 0_u16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_i32() {
-    test_scalar!(i32, 0i32);
-    test_scalar!(i32, 0i32, 1,);
-    test_scalar!(i32, 0i32, 1, 2,);
-    test_scalar!(i32, 0i32, 1, 2, 3,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(i32, 0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(i32, 0_i32);
+    test_scalar!(i32, 0_i32, 1,);
+    test_scalar!(i32, 0_i32, 1, 2,);
+    test_scalar!(i32, 0_i32, 1, 2, 3,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(i32, 0_i32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_u32() {
-    test_scalar!(u32, 0u32);
-    test_scalar!(u32, 0u32, 1,);
-    test_scalar!(u32, 0u32, 1, 2,);
-    test_scalar!(u32, 0u32, 1, 2, 3,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(u32, 0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(u32, 0_u32);
+    test_scalar!(u32, 0_u32, 1,);
+    test_scalar!(u32, 0_u32, 1, 2,);
+    test_scalar!(u32, 0_u32, 1, 2, 3,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(u32, 0_u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_i64() {
-    test_scalar!(i64, 0i64);
-    test_scalar!(i64, 0i64, 1,);
-    test_scalar!(i64, 0i64, 1, 2,);
-    test_scalar!(i64, 0i64, 1, 2, 3,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(i64, 0i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(i64, 0_i64);
+    test_scalar!(i64, 0_i64, 1,);
+    test_scalar!(i64, 0_i64, 1, 2,);
+    test_scalar!(i64, 0_i64, 1, 2, 3,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(i64, 0_i64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_u64() {
-    test_scalar!(u64, 0u64);
-    test_scalar!(u64, 0u64, 1,);
-    test_scalar!(u64, 0u64, 1, 2,);
-    test_scalar!(u64, 0u64, 1, 2, 3,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(u64, 0_u64);
+    test_scalar!(u64, 0_u64, 1,);
+    test_scalar!(u64, 0_u64, 1, 2,);
+    test_scalar!(u64, 0_u64, 1, 2, 3,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_isize() {
-    test_scalar!(isize, 0isize);
-    test_scalar!(isize, 0isize, 1,);
-    test_scalar!(isize, 0isize, 1, 2,);
-    test_scalar!(isize, 0isize, 1, 2, 3,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(isize, 0isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(isize, 0_isize);
+    test_scalar!(isize, 0_isize, 1,);
+    test_scalar!(isize, 0_isize, 1, 2,);
+    test_scalar!(isize, 0_isize, 1, 2, 3,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(isize, 0_isize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_usize() {
-    test_scalar!(usize, 0usize);
-    test_scalar!(usize, 0usize, 1,);
-    test_scalar!(usize, 0usize, 1, 2,);
-    test_scalar!(usize, 0usize, 1, 2, 3,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(usize, 0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(usize, 0_usize);
+    test_scalar!(usize, 0_usize, 1,);
+    test_scalar!(usize, 0_usize, 1, 2,);
+    test_scalar!(usize, 0_usize, 1, 2, 3,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(usize, 0_usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 }
 
 #[test]
 fn scalar_extra() {
     // test sparse case
-    test_scalar!(u64, 0u64);
-    test_scalar!(u64, 0u64, 1,);
-    test_scalar!(u64, 0u64, 2,);
-    test_scalar!(u64, 0u64, 2, 3,);
-    test_scalar!(u64, 0u64, 2, 3, 4,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8, 9,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-    test_scalar!(u64, 0u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    test_scalar!(u64, 0_u64);
+    test_scalar!(u64, 0_u64, 1,);
+    test_scalar!(u64, 0_u64, 2,);
+    test_scalar!(u64, 0_u64, 2, 3,);
+    test_scalar!(u64, 0_u64, 2, 3, 4,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8, 9,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8, 9, 10,);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    test_scalar!(u64, 0_u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 
     // test defaulting to hash table
-    test_scalar!(u64, 0u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 1500);
+    test_scalar!(u64, 0_u64, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 1500);
 
     // test default to scan
-    test_scalar!(u64, 0u64, 1500);
+    test_scalar!(u64, 0_u64, 1500);
 }
 
 #[test]

--- a/frozen-collections/tests/string_macro_tests.rs
+++ b/frozen-collections/tests/string_macro_tests.rs
@@ -1,3 +1,5 @@
+#![expect(missing_docs, reason = "Tests")]
+
 use frozen_collections::*;
 use frozen_collections_core::macros::{fz_string_map_macro, fz_string_set_macro};
 use quote::quote;
@@ -151,64 +153,10 @@ fn string() {
     test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6");
     test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7");
     test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8");
-    test_string!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9"
-    );
-    test_string!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10"
-    );
-    test_string!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11"
-    );
-    test_string!(
-        &'static str,
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12"
-    );
+    test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11");
+    test_string!(&'static str, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12");
     test_string!(
         &'static str,
         "0",
@@ -260,18 +208,7 @@ fn string() {
         "ColorMagenta"
     );
 
-    test_string!(
-        &'static str,
-        "XXA",
-        "XXB",
-        "XXC",
-        "XXD",
-        "XXE",
-        "XXF",
-        "XXG",
-        "XXH",
-        "XXHI"
-    );
+    test_string!(&'static str, "XXA", "XXB", "XXC", "XXD", "XXE", "XXF", "XXG", "XXH", "XXHI");
 }
 
 #[test]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+style_edition = "2024"
+max_width = 140

--- a/srcgen/build.rs
+++ b/srcgen/build.rs
@@ -1,3 +1,5 @@
+//! Builds source generation tests
+
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/srcgen/tests/build_script_test.rs
+++ b/srcgen/tests/build_script_test.rs
@@ -1,4 +1,4 @@
-use frozen_collections::{Len, SetQuery};
+//! Source generation tests
 
 include!(concat!(env!("OUT_DIR"), "/data.rs"));
 include!("../includes/make_collections.rs");

--- a/unstable-rustfmt.toml
+++ b/unstable-rustfmt.toml
@@ -1,0 +1,5 @@
+unstable_features = true
+
+format_code_in_doc_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
- Improved usability by implementing all the methods that were previously just on the traits as normal methods on the collections themselves. This avoids the need to import the traits to use the collections, making them more user-friendly.

- Revamped the FzStringMap/Set types. Their implementation is now simpler, yet the API is more flexible.

- Tidied up a lot of generic bounds. Many of the bounds are removed, making the types easier to use

- Enabled more lints and fixed the resulting warnings.