### PR TITLE
Add strongly-typed notion of dedupped and sorted vectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed the DefaultHashBuilder type to DefaultBuildHasher which makes more sense.
 
+- Fixed a couple bugs where undedupped vectors where being used when they should have been dedupped.
+
+- Fixed a bug where fz_ordered_map/set would sometimes produce non-working maps due to the
+  data vector not being sorted correctly.
+
 ## 0.7.0 - 2025-06-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 categories = ["data-structures", "no-std"]
 keywords = ["map", "set", "collection"]
@@ -20,15 +20,15 @@ readme = "README.md"
 rust-version = "1.87.0"
 
 [workspace.dependencies]
-frozen-collections = { version = "0.7.0", path = "frozen-collections", default-features = false }
-frozen-collections-core = { version = "0.7.0", path = "frozen-collections-core", default-features = false }
-frozen-collections-macros = { version = "0.7.0", path = "frozen-collections-macros", default-features = false }
+frozen-collections = { version = "0.8.0", path = "frozen-collections", default-features = false }
+frozen-collections-core = { version = "0.8.0", path = "frozen-collections-core", default-features = false }
+frozen-collections-macros = { version = "0.8.0", path = "frozen-collections-macros", default-features = false }
 
 const-random = "0.1.18"
 criterion = "0.6.0"
 equivalent = "1.0.2"
 foldhash = { version = "0.1.5", default-features = false }
-hashbrown = { version = "0.15.3", default-features = false }
+hashbrown = { version = "0.15.4", default-features = false }
 mutants = "0.0.3"
 proc-macro-error2 = "2.0.1"
 proc-macro2 = "1.0.95"
@@ -37,7 +37,7 @@ rand = "0.9.1"
 rand_chacha = "0.9.0"
 serde = { version = "1.0.219", default-features = false }
 serde_json = "1.0.140"
-syn = { version = "2.0.101", default-features = false }
+syn = { version = "2.0.104", default-features = false }
 
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"

--- a/frozen-collections-core/src/analyzers/hash_code_analyzer.rs
+++ b/frozen-collections-core/src/analyzers/hash_code_analyzer.rs
@@ -15,10 +15,7 @@ pub struct HashCodeAnalysisResult {
 
 /// Look for an "optimal" hash table size for a given set of hash codes.
 #[mutants::skip]
-pub fn analyze_hash_codes<I>(hash_codes: I) -> HashCodeAnalysisResult
-where
-    I: Iterator<Item = u64>,
-{
+pub fn analyze_hash_codes(hash_codes: impl Iterator<Item = u64>) -> HashCodeAnalysisResult {
     // What is a satisfactory rate of hash collisions?
     const ACCEPTABLE_COLLISION_PERCENTAGE: usize = 5;
 

--- a/frozen-collections-core/src/analyzers/scalar_key_analyzer.rs
+++ b/frozen-collections-core/src/analyzers/scalar_key_analyzer.rs
@@ -15,10 +15,7 @@ pub enum ScalarKeyAnalysisResult {
 
 /// Look for well-known patterns we can optimize for with integer keys.
 #[mutants::skip]
-pub fn analyze_scalar_keys<I>(keys: I) -> ScalarKeyAnalysisResult
-where
-    I: Iterator<Item: Scalar>,
-{
+pub fn analyze_scalar_keys(keys: impl Iterator<Item: Scalar>) -> ScalarKeyAnalysisResult {
     const MAX_SPARSE_MULTIPLIER: usize = 10;
     const ALWAYS_SPARSE_THRESHOLD: usize = 128;
 

--- a/frozen-collections-core/src/hash_tables/decl_macros.rs
+++ b/frozen-collections-core/src/hash_tables/decl_macros.rs
@@ -1,7 +1,7 @@
 macro_rules! hash_table_funcs {
     () => {
         #[inline]
-        pub(crate) fn find(&self, hash_code: u64, mut eq: impl FnMut(&T) -> bool) -> Option<&T> {
+        pub(crate) fn find(&self, hash_code: u64, eq: impl Fn(&T) -> bool) -> Option<&T> {
             #[expect(clippy::cast_possible_truncation, reason = "Truncation ok on 32 bit systems")]
             let hash_slot_index = (hash_code & self.mask) as usize;
 
@@ -30,7 +30,7 @@ macro_rules! hash_table_funcs {
         }
 
         #[inline]
-        pub(crate) fn find_mut(&mut self, hash_code: u64, mut eq: impl FnMut(&T) -> bool) -> Option<&mut T> {
+        pub(crate) fn find_mut(&mut self, hash_code: u64, eq: impl Fn(&T) -> bool) -> Option<&mut T> {
             #[expect(clippy::cast_possible_truncation, reason = "Truncation on 32 bit systems is fine")]
             let hash_slot_index = (hash_code & self.mask) as usize;
 

--- a/frozen-collections-core/src/hash_tables/hash_table_slot.rs
+++ b/frozen-collections-core/src/hash_tables/hash_table_slot.rs
@@ -22,6 +22,7 @@ where
     }
 
     /// Returns whether the hash slot is completely empty.
+    #[cfg(any(feature = "emit", feature = "macros"))]
     pub(crate) fn is_empty(&self) -> bool {
         self.max_index.into() == 0_usize
     }

--- a/frozen-collections-core/src/hash_tables/inline_hash_table_no_collisions.rs
+++ b/frozen-collections-core/src/hash_tables/inline_hash_table_no_collisions.rs
@@ -38,7 +38,7 @@ where
     CM: CollectionMagnitude,
 {
     #[inline]
-    pub(crate) fn find(&self, hash_code: u64, mut eq: impl FnMut(&T) -> bool) -> Option<&T> {
+    pub(crate) fn find(&self, hash_code: u64, eq: impl Fn(&T) -> bool) -> Option<&T> {
         #[expect(clippy::cast_possible_truncation, reason = "Truncation on 32 bit systems is fine")]
         let hash_slot_index = (hash_code & self.mask) as usize;
 
@@ -58,7 +58,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn find_mut(&mut self, hash_code: u64, mut eq: impl FnMut(&T) -> bool) -> Option<&mut T> {
+    pub(crate) fn find_mut(&mut self, hash_code: u64, eq: impl Fn(&T) -> bool) -> Option<&mut T> {
         #[expect(clippy::cast_possible_truncation, reason = "Truncation on 32 bit systems is fine")]
         let hash_slot_index = (hash_code & self.mask) as usize;
 

--- a/frozen-collections-core/src/hashers/bridge_hasher.rs
+++ b/frozen-collections-core/src/hashers/bridge_hasher.rs
@@ -37,3 +37,16 @@ where
         Self::new(BH::default())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_one() {
+        let bh = DefaultBuildHasher::default();
+        let hasher = BridgeHasher::new(bh);
+        let value = "test_string";
+        assert_eq!(hasher.hash_one(&value), bh.hash_one(value));
+    }
+}

--- a/frozen-collections-core/src/hashers/inline_left_range_hasher.rs
+++ b/frozen-collections-core/src/hashers/inline_left_range_hasher.rs
@@ -1,16 +1,13 @@
-use crate::DefaultBuildHasher;
 use crate::traits::Hasher;
 use crate::utils::cold;
 use core::hash::{BuildHasher, Hash};
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
+use foldhash::fast::FixedState;
 
 /// Hashes a portion of a left-aligned slice.
 ///
 #[doc = include_str!("../doc_snippets/private_api_warning.md")]
 #[derive(Clone, Debug)]
-pub struct InlineLeftRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = DefaultBuildHasher> {
+pub struct InlineLeftRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = FixedState> {
     bh: BH,
 }
 
@@ -78,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_left_range_hasher_hash_slice() {
-        let hasher = InlineLeftRangeHasher::<0, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineLeftRangeHasher::<0, 3>::new(FixedState::default());
         assert_eq!(
             hasher.hash_one(vec![1, 2, 3, 4].as_slice()),
             hasher.bh.hash_one(vec![1, 2, 3].as_slice())
@@ -88,21 +85,21 @@ mod tests {
 
     #[test]
     fn test_left_range_hasher_hash_string() {
-        let hasher = InlineLeftRangeHasher::<0, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineLeftRangeHasher::<0, 3>::new(FixedState::default());
         assert_eq!(hasher.hash_one(&"abcd".to_string()), hasher.bh.hash_one(b"abc"));
         assert_eq!(hasher.hash_one(&"ab".to_string()), 0);
     }
 
     #[test]
     fn test_left_range_hasher_hash_str_ref() {
-        let hasher = InlineLeftRangeHasher::<0, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineLeftRangeHasher::<0, 3>::new(FixedState::default());
         assert_eq!(hasher.hash_one(&"abcd"), hasher.bh.hash_one(b"abc"));
         assert_eq!(hasher.hash_one(&"ab"), 0);
     }
 
     #[test]
     fn test_left_range_hasher_hash_str() {
-        let hasher = InlineLeftRangeHasher::<0, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineLeftRangeHasher::<0, 3>::new(FixedState::default());
         assert_eq!(hasher.hash_one("abcd"), hasher.bh.hash_one(b"abc"));
         assert_eq!(hasher.hash_one("ab"), 0);
     }

--- a/frozen-collections-core/src/hashers/inline_right_range_hasher.rs
+++ b/frozen-collections-core/src/hashers/inline_right_range_hasher.rs
@@ -1,16 +1,13 @@
-use crate::DefaultBuildHasher;
 use crate::traits::Hasher;
 use crate::utils::cold;
 use core::hash::{BuildHasher, Hash};
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
+use foldhash::fast::FixedState;
 
 /// Hashes a portion of a right-aligned slice.
 ///
 #[doc = include_str!("../doc_snippets/private_api_warning.md")]
 #[derive(Clone, Debug)]
-pub struct InlineRightRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = DefaultBuildHasher> {
+pub struct InlineRightRangeHasher<const RANGE_START: usize, const RANGE_END: usize, BH = FixedState> {
     bh: BH,
 }
 
@@ -81,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_right_range_hasher_hash_slice() {
-        let hasher = InlineRightRangeHasher::<1, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineRightRangeHasher::<1, 3>::new(FixedState::default());
         assert_eq!(
             hasher.hash_one(vec![1, 2, 3, 4].as_slice()),
             hasher.bh.hash_one(vec![2, 3].as_slice())
@@ -95,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_right_range_hasher_hash_string() {
-        let hasher = InlineRightRangeHasher::<3, 5>::new(DefaultBuildHasher::default());
+        let hasher = InlineRightRangeHasher::<3, 5>::new(FixedState::default());
         assert_eq!(hasher.hash_one(&"abcdef".to_string()), hasher.bh.hash_one(b"bc"));
         assert_eq!(hasher.hash_one(&"abcdefghijklmn".to_string()), hasher.bh.hash_one(b"jk"));
         assert_eq!(hasher.hash_one(&"a".to_string()), 0);
@@ -103,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_right_range_hasher_hash_str_ref() {
-        let hasher = InlineRightRangeHasher::<1, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineRightRangeHasher::<1, 3>::new(FixedState::default());
         assert_eq!(hasher.hash_one(&"abcd"), hasher.bh.hash_one(b"bc"));
         assert_eq!(hasher.hash_one(&"abcdefghijklmn"), hasher.bh.hash_one(b"lm"));
         assert_eq!(hasher.hash_one(&"a"), 0);
@@ -111,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_right_range_hasher_hash_str() {
-        let hasher = InlineRightRangeHasher::<1, 3>::new(DefaultBuildHasher::default());
+        let hasher = InlineRightRangeHasher::<1, 3>::new(FixedState::default());
         assert_eq!(hasher.hash_one("abcd"), hasher.bh.hash_one(b"bc"));
         assert_eq!(hasher.hash_one("abcdefghijklmn"), hasher.bh.hash_one(b"lm"));
         assert_eq!(hasher.hash_one("a"), 0);

--- a/frozen-collections-core/src/hashers/scalar_hasher.rs
+++ b/frozen-collections-core/src/hashers/scalar_hasher.rs
@@ -15,3 +15,17 @@ where
         value.index() as u64
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ScalarHasher;
+    use crate::traits::Hasher;
+
+    #[test]
+    fn test_scalar_hasher_hash_one() {
+        let hasher = ScalarHasher;
+
+        assert_eq!(hasher.hash_one(&42u64), 42u64);
+        assert_eq!(hasher.hash_one(&0u64), 0u64);
+    }
+}

--- a/frozen-collections-core/src/lib.rs
+++ b/frozen-collections-core/src/lib.rs
@@ -26,11 +26,8 @@ mod utils;
 #[cfg(feature = "macros")]
 pub mod macros;
 
-#[cfg(feature = "emit")]
+#[cfg(any(feature = "emit", feature = "macros"))]
 pub mod emit;
-
-#[cfg(all(feature = "macros", not(feature = "emit")))]
-mod emit;
 
 /// The default hash builder used by the frozen collections.
 #[cfg(test)]

--- a/frozen-collections-core/src/macros/macro_api.rs
+++ b/frozen-collections-core/src/macros/macro_api.rs
@@ -238,7 +238,7 @@ mod tests {
             quote!({ "1111", "1112", "1113", "1114", "1115", "1116", "1117" }),
         );
 
-        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
 
         check_impl(":: FzStringSet", quote!({ x, y, z, a, b, c, d }));
@@ -256,7 +256,7 @@ mod tests {
         check_impl(":: InlineScanSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000 }));
         check_impl(":: InlineHashSet", quote!({ 1, 2, 3, 4, 5, 60000, 70000, 80000 }));
 
-        check_impl(":: InlineScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
+        check_impl(":: ScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7, 8 }));
     }
 
@@ -275,13 +275,13 @@ mod tests {
         check_impl(":: InlineScanSet", quote!({ "1", "2", "3", }));
         check_impl(":: InlineHashSet", quote!({ "1", "2", "3", "4" }));
 
-        check_impl(":: InlineScanSet", quote!({ Foo(1), Foo(2), Foo(3),}));
-        check_impl(":: EytzingerSearchSet", quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }));
+        check_impl(":: ScanSet", quote!({ Foo(1), Foo(2), Foo(3),}));
+        check_impl(":: FzOrderedSet", quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }));
 
-        check_impl(":: InlineScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
+        check_impl(":: ScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7, 8 }));
 
-        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
     }
 
@@ -300,13 +300,13 @@ mod tests {
         check_impl(":: InlineScanSet", quote!({ "1", "2", "3", }));
         check_impl(":: InlineHashSet", quote!({ "1", "2", "3", "4" }));
 
-        check_impl(":: InlineScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
-        check_impl(":: HashSet", quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }));
+        check_impl(":: ScanSet", quote!({ Foo(1), Foo(2), Foo(3), }));
+        check_impl(":: FzHashSet", quote!({ Foo(1), Foo(2), Foo(3), Foo(4) }));
 
-        check_impl(":: InlineScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
+        check_impl(":: ScanSet", quote!({ x, 2, 3, 4, 5, 6, 7 }));
         check_impl(":: FzScalarSet", quote!({ x, 2, 3, 4, 5, 6, 7, 8 }));
 
-        check_impl(":: InlineScanSet", quote!({ x, "2", "3", }));
+        check_impl(":: ScanSet", quote!({ x, "2", "3", }));
         check_impl(":: FzStringSet", quote!({ x, "2", "3", "4" }));
     }
 

--- a/frozen-collections-core/src/maps/binary_search_map.rs
+++ b/frozen-collections-core/src/maps/binary_search_map.rs
@@ -5,7 +5,7 @@ use crate::maps::decl_macros::{
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
 use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
-use crate::utils::dedup_by_keep_last;
+use crate::utils::SortedAndDeduppedVec;
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Comparable;
@@ -34,20 +34,18 @@ pub struct BinarySearchMap<K, V> {
 impl<K, V> BinarySearchMap<K, V> {
     /// Creates a frozen map.
     #[must_use]
-    pub fn new(mut entries: Vec<(K, V)>) -> Self
+    pub fn new(entries: Vec<(K, V)>) -> Self
     where
         K: Ord,
     {
-        entries.sort_by(|x, y| x.0.cmp(&y.0));
-        dedup_by_keep_last(&mut entries, |x, y| x.0.eq(&y.0));
-        Self::new_raw(entries)
+        Self::from_sorted_and_dedupped(SortedAndDeduppedVec::new(entries, |x, y| x.0.cmp(&y.0)))
     }
 
     /// Creates a frozen map.
     #[must_use]
-    pub(crate) fn new_raw(processed_entries: Vec<(K, V)>) -> Self {
+    pub(crate) fn from_sorted_and_dedupped(entries: SortedAndDeduppedVec<(K, V)>) -> Self {
         Self {
-            entries: processed_entries.into_boxed_slice(),
+            entries: entries.into_boxed_slice(),
         }
     }
 

--- a/frozen-collections-core/src/maps/eytzinger_search_map.rs
+++ b/frozen-collections-core/src/maps/eytzinger_search_map.rs
@@ -5,7 +5,7 @@ use crate::maps::decl_macros::{
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
 use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
-use crate::utils::{dedup_by_keep_last, eytzinger_search_by, eytzinger_sort};
+use crate::utils::{SortedAndDeduppedVec, eytzinger_search_by, eytzinger_sort};
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Comparable;
@@ -34,21 +34,21 @@ pub struct EytzingerSearchMap<K, V> {
 impl<K, V> EytzingerSearchMap<K, V> {
     /// Creates a frozen map.
     #[must_use]
-    pub fn new(mut entries: Vec<(K, V)>) -> Self
+    pub fn new(entries: Vec<(K, V)>) -> Self
     where
         K: Ord,
     {
-        entries.sort_by(|x, y| x.0.cmp(&y.0));
-        dedup_by_keep_last(&mut entries, |x, y| x.0.eq(&y.0));
-        eytzinger_sort(&mut entries);
-        Self::new_raw(entries)
+        let entries = SortedAndDeduppedVec::new(entries, |x, y| x.0.cmp(&y.0));
+        Self::from_sorted_and_dedupped(entries)
     }
 
     /// Creates a frozen map.
     #[must_use]
-    pub(crate) fn new_raw(processed_entries: Vec<(K, V)>) -> Self {
+    pub(crate) fn from_sorted_and_dedupped(entries: SortedAndDeduppedVec<(K, V)>) -> Self {
+        let mut entries: Vec<(K, V)> = entries.into();
+        eytzinger_sort(&mut entries);
         Self {
-            entries: processed_entries.into_boxed_slice(),
+            entries: entries.into_boxed_slice(),
         }
     }
 

--- a/frozen-collections-core/src/maps/iterators.rs
+++ b/frozen-collections-core/src/maps/iterators.rs
@@ -26,16 +26,12 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, v)| f(acc, (k, v)))
@@ -86,16 +82,12 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, v)| f(acc, (k, v)))
@@ -149,7 +141,6 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, _)| f(acc, k))
@@ -208,7 +199,6 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (_, v)| f(acc, v))
@@ -262,16 +252,12 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (_, v)| f(acc, v))
@@ -320,16 +306,12 @@ impl<K, V> Iterator for IntoIter<K, V> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, v)| f(acc, (k, v)))
@@ -385,7 +367,6 @@ impl<K, V> Iterator for IntoKeys<K, V> {
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, _)| f(acc, k))
@@ -431,7 +412,6 @@ impl<K, V> Iterator for IntoValues<K, V> {
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (_, v)| f(acc, v))

--- a/frozen-collections-core/src/maps/scan_map.rs
+++ b/frozen-collections-core/src/maps/scan_map.rs
@@ -5,7 +5,7 @@ use crate::maps::decl_macros::{
 };
 use crate::maps::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
 use crate::traits::{Len, Map, MapExtras, MapIteration, MapQuery};
-use crate::utils::dedup_by_keep_last_slow;
+use crate::utils::DeduppedVec;
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::Index;
 use equivalent::Equivalent;
@@ -33,19 +33,18 @@ pub struct ScanMap<K, V> {
 impl<K, V> ScanMap<K, V> {
     /// Creates a frozen map.
     #[must_use]
-    pub fn new(mut entries: Vec<(K, V)>) -> Self
+    pub fn new(entries: Vec<(K, V)>) -> Self
     where
         K: Eq,
     {
-        dedup_by_keep_last_slow(&mut entries, |x, y| x.0.eq(&y.0));
-        Self::new_raw(entries)
+        Self::from_dedupped(DeduppedVec::using_eq(entries, |x, y| x.0.eq(&y.0)))
     }
 
     /// Creates a frozen map.
     #[must_use]
-    pub(crate) fn new_raw(processed_entries: Vec<(K, V)>) -> Self {
+    pub(crate) fn from_dedupped(entries: DeduppedVec<(K, V)>) -> Self {
         Self {
-            entries: processed_entries.into_boxed_slice(),
+            entries: entries.into_boxed_slice(),
         }
     }
 

--- a/frozen-collections-core/src/sets/iterators.rs
+++ b/frozen-collections-core/src/sets/iterators.rs
@@ -25,16 +25,12 @@ impl<'a, T> Iterator for Iter<'a, T> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, ())| f(acc, k))
@@ -87,16 +83,12 @@ impl<T> Iterator for IntoIter<T> {
         self.inner.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.inner.count()
     }
 
     fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
         self.inner.fold(init, |acc, (k, ())| f(acc, k))
@@ -264,10 +256,7 @@ where
         self.iter.size_hint()
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.iter.count()
     }
 }

--- a/frozen-collections-core/src/utils/eytzinger.rs
+++ b/frozen-collections-core/src/utils/eytzinger.rs
@@ -43,10 +43,7 @@ pub fn eytzinger_sort<T>(data: &mut [T]) {
 ///
 /// The slice must have been previously sorted with the `eytzinger` method.
 #[inline]
-pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
-where
-    F: FnMut(&'a T) -> Ordering,
-{
+pub fn eytzinger_search_by<'a, T: 'a>(data: &'a [T], f: impl Fn(&'a T) -> Ordering) -> Option<usize> {
     let mut i = 0;
     loop {
         match data.get(i) {
@@ -71,10 +68,7 @@ where
 
 #[inline]
 #[expect(clippy::module_name_repetitions, "This is fine")]
-pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
-where
-    F: FnMut(&'a T) -> Ordering,
-{
+pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], f: impl Fn(&'a T) -> Ordering) -> Option<usize>{
 /*
     let mut i = 1;
     while (1 << NUM_PREFETCH_LEVELS) * i < data.len() {

--- a/frozen-collections/build.rs
+++ b/frozen-collections/build.rs
@@ -52,10 +52,7 @@ fn emit_loop(file: &mut BufWriter<File>, name: &str) {
     writeln!(file, "    }});").unwrap();
 }
 
-fn emit_scalar_suite<F>(file: &mut BufWriter<File>, size: usize, literal_producer: F)
-where
-    F: Fn(&mut BufWriter<File>, usize),
-{
+fn emit_scalar_suite(file: &mut BufWriter<File>, size: usize, literal_producer: impl Fn(&mut BufWriter<File>, usize)) {
     writeln!(file, "    let frozen = fz_scalar_set!({{").unwrap();
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
@@ -89,10 +86,7 @@ where
     emit_loop(file, "fz_scalar_set");
 }
 
-fn emit_string_suite<F>(file: &mut BufWriter<File>, size: usize, literal_producer: F)
-where
-    F: Fn(&mut BufWriter<File>, usize),
-{
+fn emit_string_suite(file: &mut BufWriter<File>, size: usize, literal_producer: impl Fn(&mut BufWriter<File>, usize)) {
     writeln!(file, "    let frozen = fz_string_set!({{").unwrap();
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
@@ -142,10 +136,7 @@ where
     emit_loop(file, "fz_string_set");
 }
 
-fn emit_hashed_suite<F>(file: &mut BufWriter<File>, size: usize, literal_producer: F)
-where
-    F: Fn(&mut BufWriter<File>, usize),
-{
+fn emit_hashed_suite(file: &mut BufWriter<File>, size: usize, literal_producer: impl Fn(&mut BufWriter<File>, usize)) {
     writeln!(file, "    let frozen = fz_hash_set!({{").unwrap();
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();
@@ -179,10 +170,7 @@ where
     emit_loop(file, "fz_hash_set");
 }
 
-fn emit_ordered_suite<F>(file: &mut BufWriter<File>, size: usize, literal_producer: F)
-where
-    F: Fn(&mut BufWriter<File>, usize),
-{
+fn emit_ordered_suite(file: &mut BufWriter<File>, size: usize, literal_producer: impl Fn(&mut BufWriter<File>, usize)) {
     writeln!(file, "    let frozen = fz_ordered_set!({{").unwrap();
     literal_producer(file, size);
     writeln!(file, "    }});").unwrap();


### PR DESCRIPTION
- Fixed a couple bugs where undedupped vectors where being used when they should have been dedupped.

- Fixed a bug where fz_ordered_map/set would sometimes produce non-working maps due to the
data vector not being sorted correctly.