### PR TITLE
dependencies: drop unmaintained proc_macro_error2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ frozen-collections-core = { version = "0.9.1", path = "frozen-collections-core",
 frozen-collections-macros = { version = "0.9.1", path = "frozen-collections-macros", default-features = false }
 hashbrown = { version = "0.16.1", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
-proc-macro-error2 = { version = "2.0.1", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false }
 quote = { version = "1.0.44", default-features = false }
 rand = { version = "0.10.0", default-features = false }

--- a/constants.env
+++ b/constants.env
@@ -5,7 +5,7 @@
 # used for testing, ensures the MSRV promise is kept; must match Cargo.toml [package].rust-version
 RUST_MSRV=1.90.0
 # used for static analysis & mutation testing; must match rust-toolchain.toml
-RUST_LATEST=1.93.0
+RUST_LATEST=1.97.0
 # used for coverage and extended analysis; update on a regular basis
 RUST_NIGHTLY=nightly-2026-01-21
 

--- a/frozen-collections-macros/Cargo.toml
+++ b/frozen-collections-macros/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = { workspace = true }
 frozen-collections-core = { workspace = true, features = ["macros"] }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
 
 [lints]
 workspace = true

--- a/frozen-collections-macros/src/lib.rs
+++ b/frozen-collections-macros/src/lib.rs
@@ -14,10 +14,8 @@ use frozen_collections_core::macros::{
     fz_scalar_set_macro, fz_string_map_macro, fz_string_set_macro,
 };
 use proc_macro::TokenStream;
-use proc_macro_error2::proc_macro_error;
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_hash_map(item: TokenStream) -> TokenStream {
     fz_hash_map_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -25,7 +23,6 @@ pub fn fz_hash_map(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_hash_set(item: TokenStream) -> TokenStream {
     fz_hash_set_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -33,7 +30,6 @@ pub fn fz_hash_set(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_ordered_map(item: TokenStream) -> TokenStream {
     fz_ordered_map_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -41,7 +37,6 @@ pub fn fz_ordered_map(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_ordered_set(item: TokenStream) -> TokenStream {
     fz_ordered_set_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -49,7 +44,6 @@ pub fn fz_ordered_set(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_string_map(item: TokenStream) -> TokenStream {
     fz_string_map_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -57,7 +51,6 @@ pub fn fz_string_map(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_string_set(item: TokenStream) -> TokenStream {
     fz_string_set_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -65,7 +58,6 @@ pub fn fz_string_set(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_scalar_map(item: TokenStream) -> TokenStream {
     fz_scalar_map_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -73,7 +65,6 @@ pub fn fz_scalar_map(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-#[proc_macro_error]
 pub fn fz_scalar_set(item: TokenStream) -> TokenStream {
     fz_scalar_set_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
@@ -81,7 +72,6 @@ pub fn fz_scalar_set(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Scalar)]
-#[proc_macro_error]
 pub fn derive_scalar(item: TokenStream) -> TokenStream {
     derive_scalar_macro(item.into())
         .unwrap_or_else(|error| error.to_compile_error())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # This needs to match RUST_LATEST in constants.env.
-channel = "1.93.0"
+channel = "1.97.0"


### PR DESCRIPTION
This package is unmaintained, and because it uses some deprecated syntax in rust 1.97+ anything depending on it (transitive or direct) gets a giant warning on every single cargo invocation.

https://rustsec.org/advisories/RUSTSEC-2026-0173

`proc-macro-error2` was only used for the `#[proc_macro_error]` wrapper. Our proc macro entrypoints already return errors by converting `syn::Error` into `compile_error!` tokens via `error.to_compile_error()`, so the wrapper was redundant.